### PR TITLE
Improves application structure and status visibility and adds detachable LED and Strobe visualizers

### DIFF
--- a/YALCY/.vscode/launch.json
+++ b/YALCY/.vscode/launch.json
@@ -1,6 +1,7 @@
 {
     "version": "0.2.0",
     "configurations": [
+
         {
             // Use IntelliSense to find out which attributes exist for C# debugging
             // Use hover for the description of the existing attributes

--- a/YALCY/.vscode/launch.json
+++ b/YALCY/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/bin/Debug/net9.0/YALCY.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/YALCY/.vscode/tasks.json
+++ b/YALCY/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/YALCY.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/YALCY.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/YALCY.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/YALCY/.vscode/tasks.json
+++ b/YALCY/.vscode/tasks.json
@@ -36,6 +36,25 @@
                 "${workspaceFolder}/YALCY.csproj"
             ],
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish-and-run",
+            "dependsOrder": "sequence",
+            "dependsOn": ["publish-release"],
+            "windows": {
+                "command": "cmd",
+                "args": ["/c", "start", "YALCY.exe"]
+            },
+            "options": {
+                "cwd": "${workspaceFolder}/publish"
+            },
+            "group": "build",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared"
+            }
         }
     ]
 }

--- a/YALCY/App.axaml.cs
+++ b/YALCY/App.axaml.cs
@@ -3,12 +3,26 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using YALCY.ViewModels;
 using YALCY.Views;
+using System.Reflection;
 
 namespace YALCY;
 
 public class App : Application
 {
     public MainWindowViewModel MainViewModel { get; private set; }
+
+    public static string Version
+    {
+        get
+        {
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
+            if (version != null)
+            {
+                    return $"{version.Major}.{version.Minor}.{version.Build}";
+            }
+            return "1.0.0";
+        }
+    }
 
     public override void Initialize()
     {

--- a/YALCY/Integrations/DMX/DmxTalker.cs
+++ b/YALCY/Integrations/DMX/DmxTalker.cs
@@ -6,6 +6,7 @@ using Haukcode.sACN;
 using YALCY.Integrations.StageKit;
 using YALCY.Usb;
 using YALCY.ViewModels;
+using YALCY.Views.Components;
 
 namespace YALCY.Integrations.DMX;
 
@@ -81,6 +82,7 @@ public class DmxTalker
             UpdateMasterDimmers();
             mainViewModel.UdpIntake.PacketProcessed += (packet) => UpdateDataPacket(packet, mainViewModel);
             UsbDeviceMonitor.OnStageKitCommand += OnStageKitEvent;
+            StatusFooter.UpdateStatus("DMX", IntegrationStatus.Connected);
 
             _timer = new Timer(TimeBetweenCalls * 1000);
             _timer.Elapsed += (sender, e) => Sender();
@@ -91,6 +93,7 @@ public class DmxTalker
             if (_sendClient == null) return;
 
             UsbDeviceMonitor.OnStageKitCommand -= OnStageKitEvent;
+            StatusFooter.UpdateStatus("DMX", IntegrationStatus.Off);
 
             _timer?.Stop();
             _timer?.Dispose();

--- a/YALCY/Integrations/OpenRGB/OpenRgbTalker.cs
+++ b/YALCY/Integrations/OpenRGB/OpenRgbTalker.cs
@@ -11,6 +11,7 @@ using YALCY.Udp;
 using YALCY.Usb;
 using YALCY.ViewModels;
 using Device = OpenRGB.NET.Device;
+using YALCY.Views.Components;
 
 namespace YALCY.Integrations.OpenRGB;
 
@@ -82,10 +83,12 @@ public class OpenRgbTalker
             }
 
             UsbDeviceMonitor.OnStageKitCommand += OnStageKitEvent;
+            StatusFooter.UpdateStatus("OpenRGB", IntegrationStatus.Connected);
         }
         catch (Exception ex)
         {
             mainViewModel.OpenRgbStatus = $"OpenRGB status: {ex.Message}";
+            StatusFooter.UpdateStatus("OpenRGB", IntegrationStatus.Error);
         }
     }
 
@@ -93,10 +96,12 @@ public class OpenRgbTalker
     {
         if (isEnabled)
         {
+            StatusFooter.UpdateStatus("OpenRGB", IntegrationStatus.Connecting);
             await ConnectToOpenRgbServerAsync(serverIP, serverPort);
         }
         else
         {
+            StatusFooter.UpdateStatus("OpenRGB", IntegrationStatus.Off);
             await cts.CancelAsync();
             try
             {

--- a/YALCY/Integrations/RB3E/Rb3eTalker.cs
+++ b/YALCY/Integrations/RB3E/Rb3eTalker.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Sockets;
 using YALCY.Integrations.StageKit;
 using YALCY.Usb;
+using YALCY.Views.Components;
 
 namespace YALCY.Integrations.RB3E;
 
@@ -17,12 +18,14 @@ namespace YALCY.Integrations.RB3E;
             {
                 if (_sendClient != null) return;
                 UsbDeviceMonitor.OnStageKitCommand += SendPacket;
+                StatusFooter.UpdateStatus("RB3E", IntegrationStatus.Connected);
                 _sendClient = new UdpClient();
             }
             else
             {
                 if (_sendClient == null) return;
                 UsbDeviceMonitor.OnStageKitCommand -= SendPacket;
+                StatusFooter.UpdateStatus("RB3E", IntegrationStatus.Off);
                 SendPacket(StageKitTalker.CommandId.DisableAll, 0x00);
 
                 _sendClient.Dispose();

--- a/YALCY/Integrations/Serial/SerialTalker.cs
+++ b/YALCY/Integrations/Serial/SerialTalker.cs
@@ -6,6 +6,7 @@ using HidSharp;
 using YALCY.Integrations.StageKit;
 using YALCY.Usb;
 using YALCY.ViewModels;
+using YALCY.Views.Components;
 
 namespace YALCY.Integrations.Serial;
 
@@ -27,6 +28,7 @@ public class SerialTalker: IDisposable
         if (SerialEnabled)
         {
             UsbDeviceMonitor.OnStageKitCommand += OnStageKitEvent;
+            StatusFooter.UpdateStatus("Serial", IntegrationStatus.Connected);
 
             controller = new OpenDmxController();
 
@@ -42,6 +44,7 @@ public class SerialTalker: IDisposable
             catch (Exception e)
             {
                 mainViewModel.SerialMessage = $"Error: {e.Message}";
+                StatusFooter.UpdateStatus("Serial", IntegrationStatus.Error);
                 UsbDeviceMonitor.SerialDeviceAdded += SerialDeviceAdded;  //start the watchdog.
             }
         }
@@ -152,6 +155,7 @@ public class SerialTalker: IDisposable
     public void Dispose()
     {
         UsbDeviceMonitor.OnStageKitCommand -= OnStageKitEvent;
+        StatusFooter.UpdateStatus("Serial", IntegrationStatus.Off);
         if (controller != null)
         {
             controller.Dispose();

--- a/YALCY/Integrations/StageKit/StageKitTalker.cs
+++ b/YALCY/Integrations/StageKit/StageKitTalker.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using YALCY.Udp;
 using YALCY.Usb;
+using YALCY.Views.Components;
 
 namespace YALCY.Integrations.StageKit;
 
@@ -120,12 +121,14 @@ public class StageKitTalker
             UdpIntake.OnLightingCue += CueChange;
             UdpIntake.OnStrobeState += StrobeChange;
             UdpIntake.OnFogState += FogChange;
+            StatusFooter.UpdateStatus("StageKit", IntegrationStatus.Connected);
         }
         else
         {
             UdpIntake.OnLightingCue -= CueChange;
             UdpIntake.OnStrobeState -= StrobeChange;
             UdpIntake.OnFogState -= FogChange;
+            StatusFooter.UpdateStatus("StageKit", IntegrationStatus.Off);
 
           // CueChange((byte)UdpIntake.CueByte.NoCue); Don't do this, other protocols might still be on
         }

--- a/YALCY/Models/GitHubModels.cs
+++ b/YALCY/Models/GitHubModels.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace YALCY.Models
+{
+    public class GitHubSearchResult
+    {
+        [JsonPropertyName("total_count")]
+        public int TotalCount { get; set; }
+        
+        [JsonPropertyName("incomplete_results")]
+        public bool IncompleteResults { get; set; }
+        
+        [JsonPropertyName("items")]
+        public GitHubUserInfo[]? Items { get; set; }
+    }
+
+    public class GitHubUserInfo
+    {
+        [JsonPropertyName("avatar_url")]
+        public string? AvatarUrl { get; set; }
+        
+        [JsonPropertyName("login")]
+        public string? Login { get; set; }
+        
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+        
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+        
+        [JsonPropertyName("node_id")]
+        public string? NodeId { get; set; }
+    }
+}

--- a/YALCY/ViewModels/LedDisplay.cs
+++ b/YALCY/ViewModels/LedDisplay.cs
@@ -17,52 +17,53 @@ namespace YALCY.ViewModels;
         public static readonly StyledProperty<int> ColorProperty = AvaloniaProperty.Register<LedDisplay, int>(nameof(Color));
 
         //Yeah, harded coded positions... I know, I know... I'll fix it later.
+        // Normalized LED positions (0-200 coordinate system, centered at 100,100)
         private readonly Point[] _blueLedPositions = new Point[]
         {
-            new Point(100, 32),   // LED 0
-            new Point(130, 67),   // LED 1
-            new Point(166, 98),   // LED 2
-            new Point(130, 128),  // LED 3
-            new Point(100, 164),  // LED 4
-            new Point(70, 128),   // LED 5
-            new Point(33, 98),    // LED 6
-            new Point(70, 67),    // LED 7
+            new Point(100, 32),   // LED 0 - Top
+            new Point(130, 67),   // LED 1 - Top Right
+            new Point(166, 98),   // LED 2 - Right
+            new Point(130, 128),  // LED 3 - Bottom Right
+            new Point(100, 164),  // LED 4 - Bottom
+            new Point(70, 128),   // LED 5 - Bottom Left
+            new Point(33, 98),    // LED 6 - Left
+            new Point(70, 67),    // LED 7 - Top Left
         };
 
         private readonly Point[] _greenLedPositions = new Point[]
         {
-            new Point(134, 11),   // LED 0 (green)
-            new Point(187, 65),   // LED 1 (green)
-            new Point(187, 133),  // LED 2 (green)
-            new Point(134, 186),  // LED 3 (green)
-            new Point(65, 186),   // LED 4 (green)
-            new Point(12, 133),   // LED 5 (green)
-            new Point(12, 65),    // LED 6 (green)
-            new Point(65, 11)     // LED 7 (green)
+            new Point(134, 11),   // LED 0 (green) - Outer Top
+            new Point(187, 65),   // LED 1 (green) - Outer Top Right
+            new Point(187, 133),  // LED 2 (green) - Outer Bottom Right
+            new Point(134, 186),  // LED 3 (green) - Outer Bottom
+            new Point(65, 186),   // LED 4 (green) - Outer Bottom Left
+            new Point(12, 133),   // LED 5 (green) - Outer Bottom Left
+            new Point(12, 65),    // LED 6 (green) - Outer Top Left
+            new Point(65, 11)     // LED 7 (green) - Outer Top
         };
 
         private readonly Point[] _yellowLedPositions = new Point[]
         {
-            new Point(100, -32),  // LED 0 (yellow)
-            new Point(192, 9),    // LED 1 (yellow)
-            new Point(230, 98),   // LED 2 (yellow)
-            new Point(192, 189),  // LED 3 (yellow)
-            new Point(100, 229),  // LED 4 (yellow)
-            new Point(10, 189),   // LED 5 (yellow)
-            new Point(-31, 98),   // LED 6 (yellow)
-            new Point(10, 9)      // LED 7 (yellow)
+            new Point(100, -32),  // LED 0 (yellow) - Far Top
+            new Point(192, 9),    // LED 1 (yellow) - Far Top Right
+            new Point(230, 98),   // LED 2 (yellow) - Far Right
+            new Point(192, 189),  // LED 3 (yellow) - Far Bottom Right
+            new Point(100, 229),  // LED 4 (yellow) - Far Bottom
+            new Point(10, 189),   // LED 5 (yellow) - Far Bottom Left
+            new Point(-31, 98),   // LED 6 (yellow) - Far Left
+            new Point(10, 9)      // LED 7 (yellow) - Far Top Left
         };
 
         private readonly Point[] _redLedPositions = new Point[]
         {
-            new Point(151, -24),  // LED 0 (red)
-            new Point(219, 46),   // LED 1 (red)
-            new Point(219, 152),  // LED 2 (red)
-            new Point(151, 221),  // LED 3 (red)
-            new Point(49, 221),   // LED 4 (red)
-            new Point(-23, 152),  // LED 5 (red)
-            new Point(-23, 46),   // LED 6 (red)
-            new Point(49, -24)    // LED 7 (red)
+            new Point(151, -24),  // LED 0 (red) - Farthest Top
+            new Point(219, 46),   // LED 1 (red) - Farthest Top Right
+            new Point(219, 152),  // LED 2 (red) - Farthest Right
+            new Point(151, 221),  // LED 3 (red) - Farthest Bottom Right
+            new Point(49, 221),   // LED 4 (red) - Farthest Bottom
+            new Point(-23, 152),  // LED 5 (red) - Farthest Bottom Left
+            new Point(-23, 46),   // LED 6 (red) - Farthest Left
+            new Point(49, -24)    // LED 7 (red) - Farthest Top Left
         };
 
         static LedDisplay()

--- a/YALCY/Views/Components/LedVisualizerPanel.axaml
+++ b/YALCY/Views/Components/LedVisualizerPanel.axaml
@@ -1,0 +1,22 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:YALCY.ViewModels"
+             x:Class="YALCY.Views.Components.LedVisualizerPanel"
+             mc:Ignorable="d">
+    
+    <!-- LED Visualization Panel -->
+    <Viewbox Stretch="Uniform">
+        <Canvas x:Name="CanvasContainer" Width="320" Height="320">
+            <Image x:Name="CenteredImage" Source="/Resources/StageKit/LedBackground.png" Stretch="Uniform" />
+
+            <!-- Adjust the position and size of the LedDisplay elements -->
+            <vm:LedDisplay Color="0" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="62" Canvas.Left="62" />
+            <vm:LedDisplay Color="1" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="62" Canvas.Left="62" />
+            <vm:LedDisplay Color="2" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="62" Canvas.Left="62" />
+            <vm:LedDisplay Color="3" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="62" Canvas.Left="62" />
+        </Canvas>
+    </Viewbox>
+    
+</UserControl>

--- a/YALCY/Views/Components/LedVisualizerPanel.axaml
+++ b/YALCY/Views/Components/LedVisualizerPanel.axaml
@@ -6,16 +6,16 @@
              x:Class="YALCY.Views.Components.LedVisualizerPanel"
              mc:Ignorable="d">
     
-    <!-- LED Visualization Panel -->
+    <!-- LED Visualization Panel que ocupa todo o espaço disponível -->
     <Viewbox Stretch="Uniform">
         <Canvas x:Name="CanvasContainer" Width="320" Height="320">
             <Image x:Name="CenteredImage" Source="/Resources/StageKit/LedBackground.png" Stretch="Uniform" />
 
             <!-- Adjust the position and size of the LedDisplay elements -->
-            <vm:LedDisplay Color="0" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="62" Canvas.Left="62" />
-            <vm:LedDisplay Color="1" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="62" Canvas.Left="62" />
-            <vm:LedDisplay Color="2" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="62" Canvas.Left="62" />
-            <vm:LedDisplay Color="3" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="62" Canvas.Left="62" />
+            <vm:LedDisplay Color="0" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="46" Canvas.Left="46" />
+            <vm:LedDisplay Color="1" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="46" Canvas.Left="46" />
+            <vm:LedDisplay Color="2" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="46" Canvas.Left="46" />
+            <vm:LedDisplay Color="3" HorizontalAlignment="Center" VerticalAlignment="Center" Canvas.Top="46" Canvas.Left="46" />
         </Canvas>
     </Viewbox>
     

--- a/YALCY/Views/Components/LedVisualizerPanel.axaml.cs
+++ b/YALCY/Views/Components/LedVisualizerPanel.axaml.cs
@@ -1,0 +1,72 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Media;
+using System;
+using System.Linq;
+
+namespace YALCY.Views.Components;
+
+public partial class LedVisualizerPanel : UserControl
+{
+    private bool _isInitialized = false;
+    private bool _isVisible = false;
+
+    public LedVisualizerPanel()
+    {
+        InitializeComponent();
+        
+        // Only attach events after the control is fully loaded and visible
+        this.AttachedToVisualTree += (sender, e) => 
+        {
+            if (!_isInitialized)
+            {
+                InitializeEvents();
+                _isInitialized = true;
+            }
+        };
+        
+        // Monitor visibility changes to optimize rendering
+        this.GetObservable(IsVisibleProperty).Subscribe(isVisible =>
+        {
+            _isVisible = isVisible;
+            if (isVisible && _isInitialized)
+            {
+                // Force a layout update when becoming visible
+                InvalidateArrange();
+            }
+        });
+    }
+
+    private void InitializeEvents()
+    {
+        // Center image when attached to visual tree
+        CenterImage();
+        
+        // Only listen to bounds changes when necessary and visible
+        CenteredImage.PropertyChanged += (sender, e) =>
+        {
+            if (e.Property == Image.BoundsProperty && _isInitialized && _isVisible)
+            {
+                CenterImage();
+            }
+        };
+    }
+
+    private void CenterImage()
+    {
+        if (CanvasContainer?.Bounds.Width > 0 && CenteredImage?.Bounds.Width > 0)
+        {
+            var containerBounds = CanvasContainer.Bounds;
+            var imageBounds = CenteredImage.Bounds;
+
+            // Calculate the top-left position to center the image
+            var left = (containerBounds.Width - imageBounds.Width) / 2;
+            var top = (containerBounds.Height - imageBounds.Height) / 2;
+
+            // Set Canvas.Left and Canvas.Top to position the image
+            Canvas.SetLeft(CenteredImage, left);
+            Canvas.SetTop(CenteredImage, top);
+        }
+    }
+}

--- a/YALCY/Views/Components/PersonCard.axaml
+++ b/YALCY/Views/Components/PersonCard.axaml
@@ -1,0 +1,58 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             x:Class="YALCY.Views.Components.PersonCard"
+             mc:Ignorable="d">
+    
+    <Border Background="#3a3d4a" 
+            CornerRadius="12" 
+            Padding="20" 
+            BorderBrush="#4a4d5a" 
+            BorderThickness="1"
+            MinWidth="200"
+            MaxWidth="400">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            
+            <!-- Avatar Section -->
+            <Border Grid.Column="0" 
+                    Width="48" Height="48" 
+                    CornerRadius="24" 
+                    ClipToBounds="True"
+                    Margin="0,0,15,0">
+                <Grid>
+                    <Image x:Name="AvatarImage" 
+                           Width="48" Height="48" 
+                           Stretch="UniformToFill"/>
+                    
+                    <!-- Fallback Avatar (shown when no image) -->
+                    <TextBlock x:Name="FallbackAvatar" 
+                               Text="👤" 
+                               FontSize="24" 
+                               HorizontalAlignment="Center" 
+                               VerticalAlignment="Center"
+                               IsVisible="False"/>
+                </Grid>
+            </Border>
+            
+            <!-- Info Section -->
+            <StackPanel Grid.Column="1" 
+                        VerticalAlignment="Center">
+                <TextBlock x:Name="NameText" 
+                           FontSize="17" 
+                           FontWeight="SemiBold" 
+                           Foreground="White"
+                           TextWrapping="Wrap"/>
+                <TextBlock x:Name="RoleText" 
+                           FontSize="14" 
+                           Foreground="#B0B0B0" 
+                           Margin="0,2,0,0"
+                           TextWrapping="Wrap"/>
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/YALCY/Views/Components/PersonCard.axaml.cs
+++ b/YALCY/Views/Components/PersonCard.axaml.cs
@@ -1,0 +1,201 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using YALCY.Models;
+
+namespace YALCY.Views.Components
+{
+    public partial class PersonCard : UserControl
+    {
+        private static readonly HttpClient _httpClient = new HttpClient();
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        static PersonCard()
+        {
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "YALCY-App/1.0");
+        }
+
+        public static readonly StyledProperty<string> DisplayNameProperty =
+            AvaloniaProperty.Register<PersonCard, string>(nameof(DisplayName));
+
+        public static readonly StyledProperty<string> RoleProperty =
+            AvaloniaProperty.Register<PersonCard, string>(nameof(Role));
+
+        public static readonly StyledProperty<string> GitHubUsernameProperty =
+            AvaloniaProperty.Register<PersonCard, string>(nameof(GitHubUsername));
+
+        public string DisplayName
+        {
+            get => GetValue(DisplayNameProperty);
+            set => SetValue(DisplayNameProperty, value);
+        }
+
+        public string Role
+        {
+            get => GetValue(RoleProperty);
+            set => SetValue(RoleProperty, value);
+        }
+
+        public string GitHubUsername
+        {
+            get => GetValue(GitHubUsernameProperty);
+            set => SetValue(GitHubUsernameProperty, value);
+        }
+
+        public PersonCard()
+        {
+            InitializeComponent();
+            
+            // Bind properties to UI elements
+            NameText.Text = DisplayName;
+            RoleText.Text = Role;
+            
+            // Load avatar when GitHubUsername is set
+            this.GetObservable(GitHubUsernameProperty).Subscribe(async username =>
+            {
+                await LoadGitHubAvatarAsync(username);
+            });
+            
+            // Also load avatar when DisplayName is set (for fallback cases)
+            this.GetObservable(DisplayNameProperty).Subscribe(async displayName =>
+            {
+                if (!string.IsNullOrEmpty(displayName))
+                {
+                    // Check if we already have a GitHub username
+                    var currentUsername = this.GetValue(GitHubUsernameProperty);
+                    if (string.IsNullOrEmpty(currentUsername))
+                    {
+                        await LoadGitHubAvatarAsync(""); // Force fallback
+                    }
+                }
+            });
+        }
+
+        private async Task LoadGitHubAvatarAsync(string username)
+        {
+            try
+            {
+                // Hide image and show fallback initially
+                AvatarImage.IsVisible = false;
+                FallbackAvatar.IsVisible = true;
+
+                // If username is empty, use UI Avatars API as fallback
+                if (string.IsNullOrEmpty(username))
+                {
+                    // Ensure DisplayName is not null before escaping
+                    var displayName = DisplayName ?? "Unknown";
+                    var fallbackUrl = $"https://ui-avatars.com/api/?name={Uri.EscapeDataString(displayName)}&background=random&format=png&size=96";
+                    
+                    var bitmap = await LoadImageFromUrlAsync(fallbackUrl);
+                    if (bitmap != null)
+                    {
+                        AvatarImage.Source = bitmap;
+                        AvatarImage.IsVisible = true;
+                        FallbackAvatar.IsVisible = false;
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"[PersonCard] Failed to load UI Avatars for: {displayName}");
+                    }
+                }
+                else
+                {
+                    // Try to get user info from GitHub API
+                    var userInfo = await GetGitHubUserInfoAsync(username);
+                    
+                    if (userInfo?.AvatarUrl != null)
+                    {
+                        // Load avatar image
+                        var bitmap = await LoadImageFromUrlAsync(userInfo.AvatarUrl);
+                        if (bitmap != null)
+                        {
+                            AvatarImage.Source = bitmap;
+                            AvatarImage.IsVisible = true;
+                            FallbackAvatar.IsVisible = false;
+                            return;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[PersonCard] Error loading avatar for {DisplayName ?? "Unknown"}: {ex.Message}");
+            }
+            finally
+            {
+                // Show fallback if no avatar loaded
+                if (!AvatarImage.IsVisible)
+                {
+                    FallbackAvatar.IsVisible = true;
+                }
+            }
+        }
+
+        private async Task<GitHubUserInfo?> GetGitHubUserInfoAsync(string username)
+        {
+            try
+            {
+                var url = $"https://api.github.com/search/users?q={username}+in%3Ausername";
+                var response = await _httpClient.GetStringAsync(url);
+                var searchResult = JsonSerializer.Deserialize<GitHubSearchResult>(response, _jsonOptions);
+                
+                // Find the user with exact username match
+                return searchResult?.Items?.FirstOrDefault(u => u.Login?.Equals(username, StringComparison.OrdinalIgnoreCase) == true);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private async Task<Bitmap?> LoadImageFromUrlAsync(string url)
+        {
+            try
+            {
+
+                var response = await _httpClient.GetAsync(url);
+                
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    
+                    // Try to create bitmap with explicit platform
+                    var bitmap = new Bitmap(stream);
+                    return bitmap;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[PersonCard] Error loading image: {ex.Message}");
+            }
+            return null;
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == DisplayNameProperty)
+            {
+                NameText.Text = DisplayName;
+            }
+            else if (change.Property == RoleProperty)
+            {
+                RoleText.Text = Role;
+            }
+        }
+    }
+
+
+}

--- a/YALCY/Views/Components/StatusFooter.axaml
+++ b/YALCY/Views/Components/StatusFooter.axaml
@@ -1,0 +1,73 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:YALCY.ViewModels"
+             xmlns:app="clr-namespace:YALCY"
+             x:Class="YALCY.Views.Components.StatusFooter"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d">
+
+    <Border Background="#1A1A1A" Padding="20,10,20,10" BorderBrush="#333333" BorderThickness="0,1,0,0">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            
+            <!-- Left side - Status indicators -->
+            <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="20" HorizontalAlignment="Left">
+                
+                <!-- YARG UDP -->
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                    <Ellipse Width="10" Height="10" Fill="#808080" x:Name="UdpStatusEllipse" />
+                    <TextBlock Text="YARG UDP" Foreground="White" FontSize="12" VerticalAlignment="Center" />
+                </StackPanel>
+                
+                <!-- Stage Kit -->
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                    <Ellipse Width="10" Height="10" Fill="#808080" x:Name="StageKitStatusEllipse" />
+                    <TextBlock Text="Stage Kit" Foreground="White" FontSize="12" VerticalAlignment="Center" />
+                </StackPanel>
+                
+                <!-- DMX/sACN -->
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                    <Ellipse Width="10" Height="10" Fill="#808080" x:Name="DmxStatusEllipse" />
+                    <TextBlock Text="DMX/sACN" Foreground="White" FontSize="12" VerticalAlignment="Center" />
+                </StackPanel>
+                
+                <!-- RB3E -->
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                    <Ellipse Width="10" Height="10" Fill="#808080" x:Name="Rb3eStatusEllipse" />
+                    <TextBlock Text="RB3E" Foreground="White" FontSize="12" VerticalAlignment="Center" />
+                </StackPanel>
+                
+                <!-- Serial -->
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                    <Ellipse Width="10" Height="10" Fill="#808080" x:Name="SerialStatusEllipse" />
+                    <TextBlock Text="Serial" Foreground="White" FontSize="12" VerticalAlignment="Center" />
+                </StackPanel>
+                
+                <!-- Hue -->
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                    <Ellipse Width="10" Height="10" Fill="#808080" x:Name="HueStatusEllipse" />
+                    <TextBlock Text="Hue" Foreground="White" FontSize="12" VerticalAlignment="Center" />
+                </StackPanel>
+                
+                <!-- OpenRGB -->
+                <StackPanel Orientation="Horizontal" Spacing="5">
+                    <Ellipse Width="10" Height="10" Fill="#808080" x:Name="OpenRgbStatusEllipse" />
+                    <TextBlock Text="OpenRGB" Foreground="White" FontSize="12" VerticalAlignment="Center" />
+                </StackPanel>
+                
+            </StackPanel>
+            
+            <!-- Right side - App name and version -->
+            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="5" HorizontalAlignment="Right">
+                <TextBlock Text="YALCY" Foreground="White" FontSize="12" FontWeight="Bold" VerticalAlignment="Center" />
+                <TextBlock Text="{Binding Source={x:Static app:App.Version}, StringFormat=' v{0}'}" Foreground="White" FontSize="12" VerticalAlignment="Center" />
+            </StackPanel>
+            
+        </Grid>
+    </Border>
+</UserControl>

--- a/YALCY/Views/Components/StatusFooter.axaml.cs
+++ b/YALCY/Views/Components/StatusFooter.axaml.cs
@@ -1,0 +1,173 @@
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Controls.Shapes;
+using Avalonia.Threading;
+using System;
+using System.Collections.Generic;
+
+namespace YALCY.Views.Components;
+
+public enum IntegrationStatus
+{
+    Off,        // Gray - disabled
+    Connecting, // Yellow - connecting
+    Connected,  // Green - active and connected
+    Error       // Red - active but with problem
+}
+
+public partial class StatusFooter : UserControl
+{
+    // Static events that integrations can raise to update status colors
+    public static event Action<string, string>? StatusColorChanged;
+    
+    // Dictionary to store current status colors
+    private static readonly Dictionary<string, string> _statusColors = new()
+    {
+        { "UDP", "#808080" },
+        { "StageKit", "#808080" },
+        { "DMX", "#808080" },
+        { "RB3E", "#808080" },
+        { "Serial", "#808080" },
+        { "Hue", "#808080" },
+        { "OpenRGB", "#808080" }
+    };
+
+    // References to the status ellipses
+    private Ellipse? _udpStatusEllipse;
+    private Ellipse? _stageKitStatusEllipse;
+    private Ellipse? _dmxStatusEllipse;
+    private Ellipse? _rb3eStatusEllipse;
+    private Ellipse? _serialStatusEllipse;
+    private Ellipse? _hueStatusEllipse;
+    private Ellipse? _openRgbStatusEllipse;
+
+    public StatusFooter()
+    {
+        InitializeComponent();
+        
+        // Get references to the ellipses
+        _udpStatusEllipse = this.FindControl<Ellipse>("UdpStatusEllipse");
+        _stageKitStatusEllipse = this.FindControl<Ellipse>("StageKitStatusEllipse");
+        _dmxStatusEllipse = this.FindControl<Ellipse>("DmxStatusEllipse");
+        _rb3eStatusEllipse = this.FindControl<Ellipse>("Rb3eStatusEllipse");
+        _serialStatusEllipse = this.FindControl<Ellipse>("SerialStatusEllipse");
+        _hueStatusEllipse = this.FindControl<Ellipse>("HueStatusEllipse");
+        _openRgbStatusEllipse = this.FindControl<Ellipse>("OpenRgbStatusEllipse");
+        
+        // Subscribe to status change events
+        StatusColorChanged += OnStatusColorChanged;
+        
+        // Initialize with default colors
+        UpdateAllStatusColors();
+    }
+
+    private void OnStatusColorChanged(string integrationName, string color)
+    {
+        // Verificar se a nova cor é diferente da atual para evitar mudanças desnecessárias
+        if (_statusColors.TryGetValue(integrationName, out string currentColor) && currentColor == color)
+        {
+            return; // Cor já é a mesma, não precisa mudar
+        }
+        
+        _statusColors[integrationName] = color;
+        
+        // Update the corresponding ellipse color on UI thread
+        var ellipse = GetEllipseForIntegration(integrationName);
+        if (ellipse != null)
+        {
+            // Only invoke if we're not already on UI thread
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    ellipse.Fill = new SolidColorBrush(Color.Parse(color));
+                });
+            }
+            else
+            {
+                // We're already on UI thread, update directly
+                ellipse.Fill = new SolidColorBrush(Color.Parse(color));
+            }
+        }
+    }
+
+    private Ellipse? GetEllipseForIntegration(string integrationName)
+    {
+        return integrationName.ToUpper() switch
+        {
+            "UDP" => _udpStatusEllipse,
+            "STAGEKIT" => _stageKitStatusEllipse,
+            "DMX" => _dmxStatusEllipse,
+            "RB3E" => _rb3eStatusEllipse,
+            "SERIAL" => _serialStatusEllipse,
+            "HUE" => _hueStatusEllipse,
+            "OPENRGB" => _openRgbStatusEllipse,
+            _ => null
+        };
+    }
+
+    private void UpdateAllStatusColors()
+    {
+        // Initialize all status colors to default (gray)
+        foreach (var kvp in _statusColors)
+        {
+            StatusColorChanged?.Invoke(kvp.Key, kvp.Value);
+        }
+    }
+
+    // Static methods that integrations can call directly
+    public static void UpdateStatus(string integrationName, IntegrationStatus status)
+    {
+        string color = GetStatusColor(status);
+        
+        // Verificar se a nova cor é diferente da atual para evitar chamadas desnecessárias
+        if (_statusColors.TryGetValue(integrationName, out string currentColor) && currentColor == color)
+        {
+            return; // Cor já é a mesma, não precisa mudar
+        }
+        
+        StatusColorChanged?.Invoke(integrationName, color);
+    }
+
+    public static void ToggleStatus(string integrationName, bool isEnabled)
+    {
+        string color = GetStatusColor(isEnabled ? IntegrationStatus.Connecting : IntegrationStatus.Off);
+        
+        // Verificar se a nova cor é diferente da atual para evitar chamadas desnecessárias
+        if (_statusColors.TryGetValue(integrationName, out string currentColor) && currentColor == color)
+        {
+            return; // Cor já é a mesma, não precisa mudar
+        }
+        
+        StatusColorChanged?.Invoke(integrationName, color); 
+    }
+
+    public static void SetStatusColor(string integrationName, string color)
+    {
+        // Verificar se a nova cor é diferente da atual para evitar chamadas desnecessárias
+        if (_statusColors.TryGetValue(integrationName, out string currentColor) && currentColor == color)
+        {
+            return; // Cor já é a mesma, não precisa mudar
+        }
+        
+        StatusColorChanged?.Invoke(integrationName, color);
+    }
+
+    private static string GetStatusColor(IntegrationStatus status)
+    {
+        return status switch
+        {
+            IntegrationStatus.Off => "#808080",        // Gray - disabled
+            IntegrationStatus.Connecting => "#FFFF00", // Yellow - connecting
+            IntegrationStatus.Connected => "#00FF00",  // Green - active and connected
+            IntegrationStatus.Error => "#FF0000",      // Red - active but with problem
+            _ => "#808080"                            // Default to gray
+        };
+    }
+
+    // Cleanup when control is disposed
+    ~StatusFooter()
+    {
+        StatusColorChanged -= OnStatusColorChanged;
+    }
+}

--- a/YALCY/Views/MainWindow.axaml
+++ b/YALCY/Views/MainWindow.axaml
@@ -3,15 +3,52 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:YALCY.ViewModels"
+        xmlns:tabs="clr-namespace:YALCY.Views.Tabs"
+        xmlns:components="clr-namespace:YALCY.Views.Components"
         x:Class="YALCY.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
 
         Icon="/Resources/avalonia-logo.ico"
         Title="YALCY - Yet Another Lighting Controller for YARG"
-        Width="1800" Height="1080"
+        Width="1200" Height="800"
+        MinWidth="700" MinHeight="670"
+        WindowStartupLocation="CenterOwner"
         mc:Ignorable="d">
 
     <Window.Styles>
+        <Style Selector="TabControl">
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Background="{TemplateBinding Background}"
+                            HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalAlignment}">
+                        <DockPanel>
+                            <ScrollViewer DockPanel.Dock="{TemplateBinding TabStripPlacement}" 
+                                          HorizontalAlignment="Stretch"
+                                          HorizontalScrollBarVisibility="Auto">
+                                <ItemsPresenter Name="PART_ItemsPresenter"
+                                              ItemsPanel="{TemplateBinding ItemsPanel}" />
+                            </ScrollViewer>
+                            <ContentPresenter Name="PART_SelectedContentHost"
+                                            Margin="{TemplateBinding Padding}"
+                                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                            Content="{TemplateBinding SelectedContent}"
+                                            ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
+                        </DockPanel>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+            <Setter Property="ItemsPanel">
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal"/>
+                </ItemsPanelTemplate>
+            </Setter>
+        </Style>
+        
         <Style Selector="TabControl">
             <Setter Property="BorderBrush" Value="Transparent" /> <!-- Remove the border brush -->
             <Setter Property="BorderThickness" Value="0" /> <!-- Set the border thickness to 0 -->
@@ -48,413 +85,37 @@
             <Setter Property="BorderBrush" Value="#45D8FE" /> <!-- Border color -->
         </Style>
     </Window.Styles>
-    <TabControl Margin="5">
-        <TabItem Header="YARG">
-            <Grid ColumnDefinitions="0.5*,1*" RowDefinitions="Auto,Auto,*">
-                <!-- Toggle Button -->
-                <ToggleButton ToolTip.Tip="{Binding UdpEnableSetting.ToolTip}"
-                              Content="{Binding UdpEnableSetting.ToggleButtonContent}"
-                              IsChecked="{Binding UdpEnableSetting.IsEnabled, Mode=TwoWay}" Grid.Row="0"
-                              Grid.Column="0" Margin="5" Grid.ColumnSpan="2" />
-                <!-- Port Configuration -->
-                <TextBlock Text="Listening Port:" Grid.Row="1" Grid.Column="0" Margin="5" VerticalAlignment="Center" />
-                <NumericUpDown Minimum="1" Maximum="65535" Value="{Binding UdpListenPort, Mode=TwoWay}" Grid.Row="1"
-                               Grid.Column="0" Margin="5" HorizontalAlignment="Right" />
-
-                <!-- DataGrid inside a ScrollViewer -->
-                <ScrollViewer Grid.Row="2" Grid.Column="0">
-                    <DataGrid Margin="5" BorderThickness="1" BorderBrush="Gray" GridLinesVisibility="All"
-                              CanUserResizeColumns="False" CanUserSortColumns="False"
-                              AutoGenerateColumns="False"
-                              IsReadOnly="True"
-                              ItemsSource="{Binding CombinedCollection}">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" />
-                            <DataGridTextColumn Header="Byte" Binding="{Binding Index}" Width="*" />
-                            <DataGridTextColumn Header="Current Value" Binding="{Binding Value}" Width="*" />
-                            <DataGridTextColumn Header="Value Description" Binding="{Binding ValueDescription}" />
-                        </DataGrid.Columns>
-                    </DataGrid>
-                </ScrollViewer>
-
-                <!-- LED Visualization Panel -->
-                <Canvas x:Name="CanvasContainer" Grid.Row="2" Grid.Column="1" Width="200" Height="200"
-                        HorizontalAlignment="Center" VerticalAlignment="Center">
-                    <!-- TextBox positioned above the image -->
-                    <TextBox x:Name="TextOverlay" Width="180" Canvas.Left="10" Canvas.Top="-100"
-                             HorizontalAlignment="Center" VerticalAlignment="Top" Text="Stage Kit Visualizer"
-                             Background="Transparent" Foreground="White" FontSize="16" TextAlignment="Center"
-                             BorderBrush="Transparent" />
-                    <Image x:Name="CenteredImage" Source="/Resources/StageKit/LedBackground.png" Stretch="None" />
-                    <vm:LedDisplay Color="0" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                    <vm:LedDisplay Color="1" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                    <vm:LedDisplay Color="2" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                    <vm:LedDisplay Color="3" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                </Canvas>
-            </Grid>
-        </TabItem>
-        <TabItem Header="Stage Kit">
-            <Grid RowDefinitions="Auto,*">
-                <!-- Toggle Button -->
-                <ToggleButton ToolTip.Tip="{Binding StageKitEnabledSetting.ToolTip}"
-                              Content="{Binding StageKitEnabledSetting.ToggleButtonContent}"
-                              IsChecked="{Binding StageKitEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5"
-                              Grid.Row="0" Grid.Column="0" />
-                <!-- DataGrid -->
-                <DataGrid Grid.Row="1" Grid.Column="0" CanUserSortColumns="False"
-                          ItemsSource="{Binding StageKitConnectedDevices}" AutoGenerateColumns="False" IsReadOnly="True">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Friendly Name" Binding="{Binding ProductName}" />
-                        <DataGridTextColumn Header="Instance ID" Binding="{Binding DevicePath}" />
-                        <DataGridTextColumn Header="Vendor ID" Binding="{Binding VendorID}" />
-                        <DataGridTextColumn Header="Product ID" Binding="{Binding ProductID}" />
-                        <DataGridTextColumn Header="Revision" Binding="{Binding ReleaseNumberBcd}" />
-                    </DataGrid.Columns>
-                </DataGrid>
-            </Grid>
-        </TabItem>
-        <TabItem Header="DMX/SACN">
-            <ScrollViewer>
-                <StackPanel Margin="10">
-                    <!-- Toggle Button -->
-                    <ToggleButton ToolTip.Tip="{Binding DmxEnabledSetting.ToolTip}"
-                                  Content="{Binding DmxEnabledSetting.ToggleButtonContent}"
-                                  IsChecked="{Binding DmxEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5" />
-                    <!-- Master Settings Group -->
-                    <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
-                        <StackPanel>
-                            <ItemsControl ItemsSource="{Binding MasterDimmerSettingsContainer}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <UniformGrid Columns="9">
-                                            <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[0], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[1], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[2], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[3], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[4], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[5], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[6], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[7], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                        </UniformGrid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Border>
-                    <!-- Color Channel Settings Group -->
-                    <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
-                        <StackPanel>
-                            <ItemsControl ItemsSource="{Binding ColorChannelSettingsContainer}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <UniformGrid Columns="9">
-                                            <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[0], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[1], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[2], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[3], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[4], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[5], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[6], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[7], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                        </UniformGrid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Border>
-                    <!-- Effects Channel (fog/strobe) Settings Group -->
-                    <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
-                        <StackPanel>
-                            <ItemsControl ItemsSource="{Binding EffectsChannelSettingsContainer}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <UniformGrid Columns="9">
-                                            <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[0], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[1], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[2], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[3], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[4], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[5], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[6], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Channel[7], Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                        </UniformGrid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Border>
-                    <!-- Instrument NoteS Group -->
-                    <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
-                        <StackPanel>
-                            <ItemsControl ItemsSource="{Binding InstrumentNoteSettingsContainer}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <UniformGrid Columns="2">
-                                            <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Value, Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                        </UniformGrid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <UniformGrid Columns="4" />
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Border>
-                    <!-- Advanced Settings Group -->
-                    <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
-                        <StackPanel>
-                            <ItemsControl ItemsSource="{Binding AdvancedSettingsContainer}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <UniformGrid Columns="2">
-                                            <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Value, Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                        </UniformGrid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <UniformGrid Columns="4" />
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Border>
-                    <!-- Broadcast Settings Group -->
-                    <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
-                        <StackPanel>
-                            <ItemsControl ItemsSource="{Binding BroadcastSettingsContainer}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <UniformGrid Columns="2">
-                                            <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
-                                            <NumericUpDown Minimum="1" Maximum="512"
-                                                           Value="{Binding Value, Mode=TwoWay}" Margin="5"
-                                                           HorizontalAlignment="Center" FormatString="F0" />
-                                        </UniformGrid>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <UniformGrid Columns="4" />
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Border>
-                </StackPanel>
-            </ScrollViewer>
-        </TabItem>
-        <TabItem Header="RB3E">
-            <!-- Toggle Button -->
-            <ToggleButton ToolTip.Tip="{Binding Rb3eEnabledSetting.ToolTip}"
-                          Content="{Binding Rb3eEnabledSetting.ToggleButtonContent}"
-                          IsChecked="{Binding Rb3eEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5" />
-        </TabItem>
-        <TabItem Header="Serial">
-            <StackPanel Margin="5">
-                <ToggleButton ToolTip.Tip="{Binding SerialEnabledSetting.ToolTip}"
-                              Content="{Binding SerialEnabledSetting.ToggleButtonContent}"
-                              IsChecked="{Binding SerialEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5" />
-                <TextBlock Text="The channel numbers set and used from the sAcn/dmx tab" Margin="5" />
-                <TextBlock Text="{Binding SerialMessage}" Margin="5" Foreground="Red" />
-                <!-- DataGrid -->
-                <DataGrid Grid.Row="1" Grid.Column="0" CanUserSortColumns="False" ItemsSource="{Binding SerialConnectedDevices}" AutoGenerateColumns="False" IsReadOnly="True">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="Name" Binding="{Binding FriendlyName}" />
-                        <DataGridTextColumn Header="Device Path" Binding="{Binding DevicePath}" />
-                        <DataGridTextColumn Header="File System Name" Binding="{Binding FileSystemName}" />
-                    </DataGrid.Columns>
-                </DataGrid>
-            </StackPanel>
-        </TabItem>
-
-        <TabItem Header="Hue">
-            <StackPanel Margin="5">
-                <!-- Toggle Button -->
-                <ToggleButton ToolTip.Tip="{Binding HueEnabledSetting.ToolTip}"
-                              Content="{Binding HueEnabledSetting.ToggleButtonContent}"
-                              IsChecked="{Binding HueEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5" />
-                <!-- Text Box -->
-                <TextBlock Text="Setup needed:" Margin="5" />
-                <TextBlock Text="1) Verify that your Phillips Hue Hub Bridge has software version 1948086000 or higher"
-                           Margin="5" />
-                <TextBlock Text="2) Find and enter the IP address of your hub into the box." Margin="5" />
-                <TextBlock Text="3) Create an &quot;entertainment area&quot; in your phillips hue app and name it YARG"
-                           Margin="5" />
-                <TextBlock Text="4) Add 8 lights to the area. Less will work, but you won't see full effects."
-                           Margin="5" />
-                <TextBlock
-                    Text="5) Link this program to your hub. Push the button on the hub FIRST, then click the register button"
-                    Margin="5" />
-                <!-- IP Address Input -->
-                <TextBlock Text="Enter Hue Bridge IP" />
-                <TextBox Text="{Binding HueBridgeIp}" />
-                <!-- Register Button -->
-                <Button Content="Register with Hue Bridge" Command="{Binding RegisterHueBridgeCommand}" Margin="5" />
-                <TextBlock Text="{Binding HueIpStatus}" />
-                <TextBlock Text="{Binding HueRegisterStatus}" />
-                <TextBlock Text="{Binding HueStreamingClientStatus}" />
-                <TextBlock Text="{Binding HueEntertainmentGroupStatus} " />
-                <TextBlock Text="{Binding HueStreamingActiveStatus}" />
-                <!-- Error Output -->
-                <TextBlock Text="{Binding HueMessage}" Margin="5" Foreground="Red" />
-            </StackPanel>
-        </TabItem>
-        <TabItem Header="openRGB">
-            <StackPanel Margin="5">
-                <!-- Enable Button -->
-                <ToggleButton ToolTip.Tip="{Binding  OpenRgbEnabledSetting.ToolTip}"
-                              Content="{Binding OpenRgbEnabledSetting.ToggleButtonContent}"
-                              IsChecked="{Binding OpenRgbEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5" />
-                <!-- Info -->
-                <TextBlock Text="Setup needed:" />
-                <TextBlock Text="1) OpenRgb Server needs to be running!" Margin="5" />
-                <TextBlock Text="2) Be sure your devices are in Direct mode" Margin="5" />
-                <!-- IP Address and Server port -->
-                <Grid Margin="5">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="150" /> <!-- Width for the IP TextBox -->
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="150" /> <!-- Width for the Port NumericUpDown -->
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <TextBlock Text="OpenRGB Server IP: " VerticalAlignment="Center" Margin="0,0,10,0" Grid.Column="0" />
-                    <TextBox Text="{Binding OpenRgbServerIp}" Grid.Column="1" />
-                    <TextBlock Text="OpenRGB Server Port: " VerticalAlignment="Center" Margin="10,0,10,0"
-                               Grid.Column="2" />
-                    <NumericUpDown Minimum="1" Maximum="65535" Value="{Binding OpenRgbServerPort, Mode=TwoWay}"
-                                   Grid.Column="3" />
-                    <Button Content="Connect to OpenRGB server" Command="{Binding ConnectToOpenRgbServerCommand}"
-                            Margin="10,0,0,0" Grid.Column="4" HorizontalAlignment="Right" />
-                </Grid>
-                <!-- Status Message -->
-                <TextBlock Text="{Binding OpenRgbStatus}" />
-                <!-- Data Grid -->
-                <DataGrid CanUserSortColumns="False" ItemsSource="{Binding DeviceCategories}"
-                          AutoGenerateColumns="False" IsReadOnly="True">
-                    <DataGrid.Columns>
-                        <DataGridTemplateColumn Header="Category">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal">
-                                        <RadioButton Content="Off" GroupName="{Binding Device.Index}" Margin="5,0"
-                                                     IsChecked="{Binding Category, Converter={StaticResource IntToBoolConverter}, ConverterParameter=0}" />
-
-                                        <RadioButton Content="LightPod" GroupName="{Binding Device.Index}" Margin="5,0"
-                                                     IsChecked="{Binding Category, Converter={StaticResource IntToBoolConverter}, ConverterParameter=1}" />
-
-                                        <RadioButton Content="Strobe" GroupName="{Binding Device.Index}" Margin="5,0"
-                                                     IsChecked="{Binding Category, Converter={StaticResource IntToBoolConverter}, ConverterParameter=2}" />
-
-                                        <RadioButton Content="Fogger" GroupName="{Binding Device.Index}" Margin="5,0"
-                                                     IsChecked="{Binding Category, Mode=TwoWay, Converter={StaticResource IntToBoolConverter}, ConverterParameter=3}" />
-                                    </StackPanel>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
-                        <DataGridTextColumn Header="Index" Binding="{Binding Device.Index}" />
-                        <DataGridTextColumn Header="Type" Binding="{Binding Device.Type}" />
-                        <DataGridTextColumn Header="Name" Binding="{Binding Device.Name}" />
-                        <DataGridTextColumn Header="Vendor" Binding="{Binding Device.Vendor}" />
-                        <DataGridTextColumn Header="Description" Binding="{Binding Device.Description}" />
-                        <DataGridTextColumn Header="Version" Binding="{Binding Device.Version}" />
-                        <DataGridTextColumn Header="Serial" Binding="{Binding Device.Serial}" />
-                        <DataGridTextColumn Header="Location" Binding="{Binding Device.Location}" />
-                        <DataGridTextColumn Header="Active Mode Index" Binding="{Binding Device.ActiveModeIndex}" />
-                        <DataGridTextColumn Header="Modes" Binding="{Binding Device.Modes.Length}" />
-                        <DataGridTextColumn Header="Zones" Binding="{Binding Device.Zones.Length}" />
-                        <DataGridTextColumn Header="Leds" Binding="{Binding Device.Leds.Length}" />
-                        <DataGridTextColumn Header="Colors" Binding="{Binding Device.Colors.Length}" />
-                    </DataGrid.Columns>
-                </DataGrid>
-            </StackPanel>
-        </TabItem>
-        <TabItem Header="Credits">
-            <TextBlock Margin="5">
-                <TextBlock.Inlines>
-                    <Run Text="Contributors:" />
-                    <LineBreak />
-                    <Run Text="Kadu" />
-                    <LineBreak />
-                    <Run Text="The Fat Bastid" />
-                    <LineBreak />                    
-                    <Run Text="Nyxyxylyth" />
-                    <LineBreak />
-                    <LineBreak />
-                    <Run Text="Special thanks to:" />
-                    <LineBreak />
-                    <Run Text="RPAL" />
-                    <LineBreak />
-                    <Run Text="RazQ" />
-                    <LineBreak />
-                    <Run Text="Alink2thepatrick" />
-                    <LineBreak />
-                    <Run Text="NevesPT" />
-                    <LineBreak />
-                    <Run Text="and, of course, everyone from the YARG mother-ship." />
-                </TextBlock.Inlines>
-            </TextBlock>
-
-        </TabItem>
-    </TabControl>
+    
+    <Grid RowDefinitions="*,Auto">
+        <!-- Main content area -->
+        <TabControl Grid.Row="0" Margin="5" TabStripPlacement="Top">
+            <TabItem Header="YARG">
+                <tabs:YargTabView />
+            </TabItem>
+            <TabItem Header="Stage Kit">
+                <tabs:StageKitTabView />
+            </TabItem>
+            <TabItem Header="DMX/SACN">
+                <tabs:DmxSacnTabView />
+            </TabItem>
+            <TabItem Header="RB3E">
+                <tabs:Rb3eTabView />
+            </TabItem>
+            <TabItem Header="Serial">
+                <tabs:SerialTabView />
+            </TabItem>
+            <TabItem Header="Hue">
+                <tabs:HueTabView />
+            </TabItem>
+            <TabItem Header="openRGB">
+                <tabs:OpenRgbTabView />
+            </TabItem>
+            <TabItem Header="Credits">
+                <tabs:CreditsTabView />
+            </TabItem>
+        </TabControl>
+        
+        <!-- Status Footer -->
+        <components:StatusFooter Grid.Row="1" />
+    </Grid>
 </Window>

--- a/YALCY/Views/MainWindow.axaml.cs
+++ b/YALCY/Views/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using YALCY.Views.Tabs;
 
 namespace YALCY.Views;
 
@@ -7,5 +8,14 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        
+        // Close all detached windows when main window is closing
+        this.Closing += OnMainWindowClosing;
+    }
+    
+    private void OnMainWindowClosing(object? sender, WindowClosingEventArgs e)
+    {
+        // Close all detached windows first
+        YargTabView.CloseAllDetachedWindows();
     }
 }

--- a/YALCY/Views/MainWindow.axaml.cs
+++ b/YALCY/Views/MainWindow.axaml.cs
@@ -7,27 +7,5 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-        CenteredImage.AttachedToVisualTree += (sender, e) => CenterImage();
-        CenteredImage.PropertyChanged += (sender, e) =>
-        {
-            if (e.Property == BoundsProperty)
-            {
-                CenterImage();
-            }
-        };
-    }
-
-    private void CenterImage()
-    {
-        var containerBounds = CanvasContainer.Bounds;
-        var imageBounds = CenteredImage.Bounds;
-
-        // Calculate the top-left position to center the image
-        var left = (containerBounds.Width - imageBounds.Width) / 2;
-        var top = (containerBounds.Height - imageBounds.Height) / 2;
-
-        // Set Canvas.Left and Canvas.Top to position the image
-        Canvas.SetLeft(CenteredImage, left);
-        Canvas.SetTop(CenteredImage, top);
     }
 }

--- a/YALCY/Views/Tabs/CreditsTabView.axaml
+++ b/YALCY/Views/Tabs/CreditsTabView.axaml
@@ -1,0 +1,147 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:components="clr-namespace:YALCY.Views.Components"
+             x:Class="YALCY.Views.Tabs.CreditsTabView"
+             mc:Ignorable="d">
+    
+    <ScrollViewer>
+        <StackPanel Margin="25" Spacing="30">
+            
+            <!-- Header with subtle gradient -->
+            <Border CornerRadius="16" 
+                    Padding="35" 
+                    Margin="0,0,0,10"
+                    Background="#2a2d3a"
+                    BorderBrush="#3a3d4a"
+                    BorderThickness="1">
+                <StackPanel HorizontalAlignment="Center">
+                    <TextBlock Text="🎉" 
+                               FontSize="42" 
+                               HorizontalAlignment="Center" 
+                               Margin="0,0,0,15"/>
+                    <TextBlock Text="YALCY Credits" 
+                               FontSize="26" 
+                               FontWeight="Bold" 
+                               Foreground="White" 
+                               HorizontalAlignment="Center"/>
+                    <TextBlock Text="Made with ❤️ by the community" 
+                               FontSize="15" 
+                               Foreground="#B0B0B0" 
+                               HorizontalAlignment="Center" 
+                               Margin="0,8,0,0"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Core Contributors Section -->
+            <Border Background="#2a2d3a" 
+                    CornerRadius="16" 
+                    Padding="30" 
+                    BorderBrush="#3a3d4a" 
+                    BorderThickness="1">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" 
+                                HorizontalAlignment="Center" 
+                                Margin="0,0,0,25">
+                        <TextBlock Text="Core Contributors" 
+                                   FontSize="20" 
+                                   FontWeight="Bold" 
+                                   Foreground="White"/>
+                    </StackPanel>
+                    
+                    <UniformGrid Columns="2" Margin="10,0,0,0">
+                        <!-- The Fat Bastid -->
+                        <components:PersonCard  DisplayName="The Fat Bastid" 
+                                                Role="Developer" 
+                                                GitHubUsername="TheFatBastid"
+                                                Margin="0,0,7,15"/>
+
+                         <!-- Kadu -->
+                         <components:PersonCard DisplayName="Kadu" 
+                                                Role="Designer" 
+                                                GitHubUsername="kaduwaengertner"
+                                                Margin="7,0,0,15"/>
+                         
+                        
+                         <!-- Nyxyxylyth -->
+                         <components:PersonCard DisplayName="Nyxyxylyth" 
+                                                Role="Developer" 
+                                                GitHubUsername="Nyxyxylyth"
+                                                Margin="0,0,7,0"/>
+
+                        <!-- NevesPT -->
+                        <components:PersonCard  DisplayName="NevesPT" 
+                                                Role="Developer"
+                                                GitHubUsername="nevespt"
+                                                Margin="7,0,0,0"/>
+                     </UniformGrid>
+                </StackPanel>
+            </Border>
+
+            <!-- Special Thanks Section -->
+            <Border Background="#2a2d3a" 
+                    CornerRadius="16" 
+                    Padding="30" 
+                    BorderBrush="#3a3d4a" 
+                    BorderThickness="1">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" 
+                                HorizontalAlignment="Center" 
+                                Margin="0,0,0,25">
+                        <TextBlock Text="Special Thanks" 
+                                   FontSize="20" 
+                                   FontWeight="Bold" 
+                                   Foreground="White"/>
+                    </StackPanel>
+                    
+                    <UniformGrid Columns="2" Margin="10,0,0,0">
+                            <!-- RPAL -->
+                           <components:PersonCard DisplayName="RPAL" 
+                                                  Role="Community Member"
+                                                  Margin="0,0,7,15"/>
+                           
+                           <!-- RazQ -->
+                           <components:PersonCard DisplayName="RazQ" 
+                                                  Role="Community Member"
+                                                  Margin="7,0,0,15"/>
+                           
+                           <!-- Alink2thepatrick -->
+                           <components:PersonCard DisplayName="Alink2thepatrick" 
+                                                  Role="Community Member"
+                                                  Margin="0,0,7,0"/>
+                           
+                           <!-- YARG -->
+                           <components:PersonCard DisplayName="YARG Team" 
+                                                  Role="and, of course, everyone from the YARG mother-ship"
+                                                  GitHubUsername="YARC-Official"
+                                                  Margin="7,0,0,0"/>
+                           
+                       </UniformGrid>
+                </StackPanel>
+            </Border>
+
+            <!-- Footer -->
+            <Border Background="#1a1d2a" 
+                    CornerRadius="16" 
+                    Padding="30" 
+                    BorderBrush="#2a2d3a" 
+                    BorderThickness="1">
+                <StackPanel HorizontalAlignment="Center">
+                    <TextBlock Text="♫" FontSize="32" HorizontalAlignment="Center" Margin="0,0,0,12"/>
+                    <TextBlock Text="Thank you for using YALCY!" 
+                               FontSize="17" 
+                               FontWeight="SemiBold" 
+                               Foreground="White" 
+                               HorizontalAlignment="Center"/>
+                    <TextBlock Text="Keep rocking and keep the music alive!" 
+                               FontSize="15" 
+                               Foreground="#B0B0B0" 
+                               HorizontalAlignment="Center" 
+                               Margin="0,6,0,0"/>
+                </StackPanel>
+            </Border>
+            
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/YALCY/Views/Tabs/CreditsTabView.axaml.cs
+++ b/YALCY/Views/Tabs/CreditsTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace YALCY.Views.Tabs;
+
+public partial class CreditsTabView : UserControl
+{
+    public CreditsTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YALCY/Views/Tabs/DmxSacnTabView.axaml
+++ b/YALCY/Views/Tabs/DmxSacnTabView.axaml
@@ -1,0 +1,197 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:YALCY.ViewModels"
+             x:Class="YALCY.Views.Tabs.DmxSacnTabView"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d">
+    <ScrollViewer>
+        <StackPanel Margin="10">
+            <!-- Toggle Button -->
+            <ToggleButton ToolTip.Tip="{Binding DmxEnabledSetting.ToolTip}"
+                          Content="{Binding DmxEnabledSetting.ToggleButtonContent}"
+                          IsChecked="{Binding DmxEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5" />
+            <!-- Master Settings Group -->
+            <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding MasterDimmerSettingsContainer}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <UniformGrid Columns="9">
+                                    <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[0], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[1], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[2], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[3], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[4], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[5], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[6], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[7], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                </UniformGrid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+            <!-- Color Channel Settings Group -->
+            <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding ColorChannelSettingsContainer}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <UniformGrid Columns="9">
+                                    <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[0], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[1], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[2], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[3], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[4], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[5], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[6], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[7], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                </UniformGrid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+            <!-- Effects Channel (fog/strobe) Settings Group -->
+            <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding EffectsChannelSettingsContainer}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <UniformGrid Columns="9">
+                                    <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[0], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[1], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[2], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[3], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[4], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[5], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[6], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Channel[7], Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                </UniformGrid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+            <!-- Instrument NoteS Group -->
+            <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding InstrumentNoteSettingsContainer}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <UniformGrid Columns="2">
+                                    <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Value, Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                </UniformGrid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <UniformGrid Columns="4" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+            <!-- Advanced Settings Group -->
+            <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding AdvancedSettingsContainer}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <UniformGrid Columns="2">
+                                    <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Value, Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                </UniformGrid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <UniformGrid Columns="4" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+            <!-- Broadcast Settings Group -->
+            <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
+                <StackPanel>
+                    <ItemsControl ItemsSource="{Binding BroadcastSettingsContainer}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <UniformGrid Columns="2">
+                                    <TextBlock Text="{Binding Label}" VerticalAlignment="Center" Margin="5" />
+                                    <NumericUpDown Minimum="1" Maximum="512"
+                                                   Value="{Binding Value, Mode=TwoWay}" Margin="5"
+                                                   HorizontalAlignment="Center" FormatString="F0" />
+                                </UniformGrid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <UniformGrid Columns="4" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/YALCY/Views/Tabs/DmxSacnTabView.axaml.cs
+++ b/YALCY/Views/Tabs/DmxSacnTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace YALCY.Views.Tabs;
+
+public partial class DmxSacnTabView : UserControl
+{
+    public DmxSacnTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YALCY/Views/Tabs/HueTabView.axaml
+++ b/YALCY/Views/Tabs/HueTabView.axaml
@@ -1,0 +1,39 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:YALCY.ViewModels"
+             x:Class="YALCY.Views.Tabs.HueTabView"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d">
+    <StackPanel Margin="5">
+        <!-- Toggle Button -->
+        <ToggleButton ToolTip.Tip="{Binding HueEnabledSetting.ToolTip}"
+                      Content="{Binding HueEnabledSetting.ToggleButtonContent}"
+                      IsChecked="{Binding HueEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5" />
+        <!-- Text Box -->
+        <TextBlock Text="Setup needed:" Margin="5" />
+        <TextBlock Text="1) Verify that your Phillips Hue Hub Bridge has software version 1948086000 or higher"
+                   Margin="5" />
+        <TextBlock Text="2) Find and enter the IP address of your hub into the box." Margin="5" />
+        <TextBlock Text="3) Create an &quot;entertainment area&quot; in your phillips hue app and name it YARG"
+                   Margin="5" />
+        <TextBlock Text="4) Add 8 lights to the area. Less will work, but you won't see full effects."
+                   Margin="5" />
+        <TextBlock
+            Text="5) Link this program to your hub. Push the button on the hub FIRST, then click the register button"
+            Margin="5" />
+        <!-- IP Address Input -->
+        <TextBlock Text="Enter Hue Bridge IP" />
+        <TextBox Text="{Binding HueBridgeIp}" />
+        <!-- Register Button -->
+        <Button Content="Register with Hue Bridge" Command="{Binding RegisterHueBridgeCommand}" Margin="5" />
+        <TextBlock Text="{Binding HueIpStatus}" />
+        <TextBlock Text="{Binding HueRegisterStatus}" />
+        <TextBlock Text="{Binding HueStreamingClientStatus}" />
+        <TextBlock Text="{Binding HueEntertainmentGroupStatus} " />
+        <TextBlock Text="{Binding HueStreamingActiveStatus}" />
+        <!-- Error Output -->
+        <TextBlock Text="{Binding HueMessage}" Margin="5" Foreground="Red" />
+    </StackPanel>
+</UserControl>

--- a/YALCY/Views/Tabs/HueTabView.axaml.cs
+++ b/YALCY/Views/Tabs/HueTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace YALCY.Views.Tabs;
+
+public partial class HueTabView : UserControl
+{
+    public HueTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YALCY/Views/Tabs/OpenRgbTabView.axaml
+++ b/YALCY/Views/Tabs/OpenRgbTabView.axaml
@@ -1,0 +1,77 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:YALCY.ViewModels"
+             x:Class="YALCY.Views.Tabs.OpenRgbTabView"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d">
+    <StackPanel Margin="5">
+        <!-- Enable Button -->
+        <ToggleButton ToolTip.Tip="{Binding  OpenRgbEnabledSetting.ToolTip}"
+                      Content="{Binding OpenRgbEnabledSetting.ToggleButtonContent}"
+                      IsChecked="{Binding OpenRgbEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5" />
+        <!-- Info -->
+        <TextBlock Text="Setup needed:" />
+        <TextBlock Text="1) OpenRgb Server needs to be running!" Margin="5" />
+        <TextBlock Text="2) Be sure your devices are in Direct mode" Margin="5" />
+        <!-- IP Address and Server port -->
+        <Grid Margin="5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="150" /> <!-- Width for the IP TextBox -->
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="150" /> <!-- Width for the Port NumericUpDown -->
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="OpenRGB Server IP: " VerticalAlignment="Center" Margin="0,0,10,0" Grid.Column="0" />
+            <TextBox Text="{Binding OpenRgbServerIp}" Grid.Column="1" />
+            <TextBlock Text="OpenRGB Server Port: " VerticalAlignment="Center" Margin="10,0,10,0"
+                       Grid.Column="2" />
+            <NumericUpDown Minimum="1" Maximum="65535" Value="{Binding OpenRgbServerPort, Mode=TwoWay}"
+                           Grid.Column="3" />
+            <Button Content="Connect to OpenRGB server" Command="{Binding ConnectToOpenRgbServerCommand}"
+                    Margin="10,0,0,0" Grid.Column="4" HorizontalAlignment="Right" />
+        </Grid>
+        <!-- Status Message -->
+        <TextBlock Text="{Binding OpenRgbStatus}" />
+        <!-- Data Grid -->
+        <DataGrid CanUserSortColumns="False" ItemsSource="{Binding DeviceCategories}"
+                  AutoGenerateColumns="False" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTemplateColumn Header="Category">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <RadioButton Content="Off" GroupName="{Binding Device.Index}" Margin="5,0"
+                                             IsChecked="{Binding Category, Converter={StaticResource IntToBoolConverter}, ConverterParameter=0}" />
+
+                                <RadioButton Content="LightPod" GroupName="{Binding Device.Index}" Margin="5,0"
+                                             IsChecked="{Binding Category, Converter={StaticResource IntToBoolConverter}, ConverterParameter=1}" />
+
+                                <RadioButton Content="Strobe" GroupName="{Binding Device.Index}" Margin="5,0"
+                                             IsChecked="{Binding Category, Converter={StaticResource IntToBoolConverter}, ConverterParameter=2}" />
+
+                                <RadioButton Content="Fogger" GroupName="{Binding Device.Index}" Margin="5,0"
+                                             IsChecked="{Binding Category, Mode=TwoWay, Converter={StaticResource IntToBoolConverter}, ConverterParameter=3}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Header="Index" Binding="{Binding Device.Index}" />
+                <DataGridTextColumn Header="Type" Binding="{Binding Device.Type}" />
+                <DataGridTextColumn Header="Name" Binding="{Binding Device.Name}" />
+                <DataGridTextColumn Header="Vendor" Binding="{Binding Device.Vendor}" />
+                <DataGridTextColumn Header="Description" Binding="{Binding Device.Description}" />
+                <DataGridTextColumn Header="Version" Binding="{Binding Device.Version}" />
+                <DataGridTextColumn Header="Serial" Binding="{Binding Device.Serial}" />
+                <DataGridTextColumn Header="Location" Binding="{Binding Device.Location}" />
+                <DataGridTextColumn Header="Active Mode Index" Binding="{Binding Device.ActiveModeIndex}" />
+                <DataGridTextColumn Header="Modes" Binding="{Binding Device.Modes.Length}" />
+                <DataGridTextColumn Header="Zones" Binding="{Binding Device.Zones.Length}" />
+                <DataGridTextColumn Header="Leds" Binding="{Binding Device.Leds.Length}" />
+                <DataGridTextColumn Header="Colors" Binding="{Binding Device.Colors.Length}" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </StackPanel>
+</UserControl>

--- a/YALCY/Views/Tabs/OpenRgbTabView.axaml.cs
+++ b/YALCY/Views/Tabs/OpenRgbTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace YALCY.Views.Tabs;
+
+public partial class OpenRgbTabView : UserControl
+{
+    public OpenRgbTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YALCY/Views/Tabs/Rb3eTabView.axaml
+++ b/YALCY/Views/Tabs/Rb3eTabView.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:YALCY.ViewModels"
+             x:Class="YALCY.Views.Tabs.Rb3eTabView"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d">
+    <!-- Toggle Button -->
+    <ToggleButton ToolTip.Tip="{Binding Rb3eEnabledSetting.ToolTip}"
+                  Content="{Binding Rb3eEnabledSetting.ToggleButtonContent}"
+                  IsChecked="{Binding Rb3eEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5" />
+</UserControl>

--- a/YALCY/Views/Tabs/Rb3eTabView.axaml.cs
+++ b/YALCY/Views/Tabs/Rb3eTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace YALCY.Views.Tabs;
+
+public partial class Rb3eTabView : UserControl
+{
+    public Rb3eTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YALCY/Views/Tabs/SerialTabView.axaml
+++ b/YALCY/Views/Tabs/SerialTabView.axaml
@@ -1,0 +1,24 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:YALCY.ViewModels"
+             x:Class="YALCY.Views.Tabs.SerialTabView"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d">
+    <StackPanel Margin="5">
+        <ToggleButton ToolTip.Tip="{Binding SerialEnabledSetting.ToolTip}"
+                      Content="{Binding SerialEnabledSetting.ToggleButtonContent}"
+                      IsChecked="{Binding SerialEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5" />
+        <TextBlock Text="The channel numbers set and used from the sAcn/dmx tab" Margin="5" />
+        <TextBlock Text="{Binding SerialMessage}" Margin="5" Foreground="Red" />
+        <!-- DataGrid -->
+        <DataGrid Grid.Row="1" Grid.Column="0" CanUserSortColumns="False" ItemsSource="{Binding SerialConnectedDevices}" AutoGenerateColumns="False" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name" Binding="{Binding FriendlyName}" />
+                <DataGridTextColumn Header="Device Path" Binding="{Binding DevicePath}" />
+                <DataGridTextColumn Header="File System Name" Binding="{Binding FileSystemName}" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </StackPanel>
+</UserControl>

--- a/YALCY/Views/Tabs/SerialTabView.axaml.cs
+++ b/YALCY/Views/Tabs/SerialTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace YALCY.Views.Tabs;
+
+public partial class SerialTabView : UserControl
+{
+    public SerialTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YALCY/Views/Tabs/StageKitTabView.axaml
+++ b/YALCY/Views/Tabs/StageKitTabView.axaml
@@ -1,0 +1,27 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:YALCY.ViewModels"
+             x:Class="YALCY.Views.Tabs.StageKitTabView"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d">
+    <Grid RowDefinitions="Auto,*">
+        <!-- Toggle Button -->
+        <ToggleButton ToolTip.Tip="{Binding StageKitEnabledSetting.ToolTip}"
+                      Content="{Binding StageKitEnabledSetting.ToggleButtonContent}"
+                      IsChecked="{Binding StageKitEnabledSetting.IsEnabled, Mode=TwoWay}" Margin="5"
+                      Grid.Row="0" Grid.Column="0" />
+        <!-- DataGrid -->
+        <DataGrid Grid.Row="1" Grid.Column="0" CanUserSortColumns="False"
+                  ItemsSource="{Binding StageKitConnectedDevices}" AutoGenerateColumns="False" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Friendly Name" Binding="{Binding ProductName}" />
+                <DataGridTextColumn Header="Instance ID" Binding="{Binding DevicePath}" />
+                <DataGridTextColumn Header="Vendor ID" Binding="{Binding VendorID}" />
+                <DataGridTextColumn Header="Product ID" Binding="{Binding ProductID}" />
+                <DataGridTextColumn Header="Revision" Binding="{Binding ReleaseNumberBcd}" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</UserControl>

--- a/YALCY/Views/Tabs/StageKitTabView.axaml.cs
+++ b/YALCY/Views/Tabs/StageKitTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace YALCY.Views.Tabs;
+
+public partial class StageKitTabView : UserControl
+{
+    public StageKitTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YALCY/Views/Tabs/YargTabView.axaml
+++ b/YALCY/Views/Tabs/YargTabView.axaml
@@ -11,11 +11,11 @@
         <!-- Toggle Button -->
         <ToggleButton ToolTip.Tip="{Binding UdpEnableSetting.ToolTip}" Content="{Binding UdpEnableSetting.ToggleButtonContent}" IsChecked="{Binding UdpEnableSetting.IsEnabled, Mode=TwoWay}" Grid.Row="0" Grid.Column="0" Margin="5" Grid.ColumnSpan="2" />
 
-        <!-- Detach Visualizer Button
+        <!-- Detach Visualizer Button -->
         <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1" Margin="5" HorizontalAlignment="Right" Spacing="10">
             <ToggleButton x:Name="StrobeVisualizerButton" Content="Strobe Visualizer" Click="OnStrobeVisualizerClicked" />
             <ToggleButton x:Name="DetachVisualizerButton" Content="Detach LED Visualizer" Click="OnDetachVisualizerClicked" />
-        </StackPanel> -->
+        </StackPanel> 
 
         <!-- Port Configuration -->
         <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="0" Margin="5">

--- a/YALCY/Views/Tabs/YargTabView.axaml
+++ b/YALCY/Views/Tabs/YargTabView.axaml
@@ -1,0 +1,39 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:YALCY.ViewModels"
+             xmlns:components="clr-namespace:YALCY.Views.Components"
+             x:Class="YALCY.Views.Tabs.YargTabView"
+             x:DataType="vm:MainWindowViewModel"
+             mc:Ignorable="d">
+    <Grid x:Name="MainGrid" ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto,Auto,*">
+        <!-- Toggle Button -->
+        <ToggleButton ToolTip.Tip="{Binding UdpEnableSetting.ToolTip}" Content="{Binding UdpEnableSetting.ToggleButtonContent}" IsChecked="{Binding UdpEnableSetting.IsEnabled, Mode=TwoWay}" Grid.Row="0" Grid.Column="0" Margin="5" Grid.ColumnSpan="2" />
+
+        <!-- Detach Visualizer Button
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Grid.Column="1" Margin="5" HorizontalAlignment="Right" Spacing="10">
+            <ToggleButton x:Name="StrobeVisualizerButton" Content="Strobe Visualizer" Click="OnStrobeVisualizerClicked" />
+            <ToggleButton x:Name="DetachVisualizerButton" Content="Detach LED Visualizer" Click="OnDetachVisualizerClicked" />
+        </StackPanel> -->
+
+        <!-- Port Configuration -->
+        <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="0" Margin="5">
+            <TextBlock Text="Listening Port:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <NumericUpDown Minimum="1" Maximum="65535" Value="{Binding UdpListenPort, Mode=TwoWay}" MinWidth="80" />
+        </StackPanel>
+
+        <!-- DataGrid with internal scroll -->
+        <DataGrid x:Name="MainDataGrid" Grid.Row="3" Grid.Column="0" Margin="5" BorderThickness="1" BorderBrush="Gray" GridLinesVisibility="All" CanUserResizeColumns="False" CanUserSortColumns="False" ItemsSource="{Binding CombinedCollection}" AutoGenerateColumns="False" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                <DataGridTextColumn Header="Byte" Binding="{Binding Index}" Width="*"/>
+                <DataGridTextColumn Header="Current Value" Binding="{Binding Value}" Width="*"/>
+                <DataGridTextColumn Header="Value Description" Binding="{Binding ValueDescription}" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- LED Visualization Panel (will be dynamically managed) -->
+        <components:LedVisualizerPanel x:Name="LedVisualizer" Grid.Row="3" Margin="20" Grid.Column="1" Width="320" Height="320" />
+    </Grid>
+</UserControl>

--- a/YALCY/Views/Tabs/YargTabView.axaml.cs
+++ b/YALCY/Views/Tabs/YargTabView.axaml.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Platform;
+using YALCY.Views.Components;
+
+namespace YALCY.Views.Tabs;
+
+public partial class YargTabView : UserControl
+{
+    public YargTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/YALCY/Views/Tabs/YargTabView.axaml.cs
+++ b/YALCY/Views/Tabs/YargTabView.axaml.cs
@@ -5,13 +5,219 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Platform;
 using YALCY.Views.Components;
+using YALCY.Views.Windows;
+using Avalonia.Interactivity;
 
 namespace YALCY.Views.Tabs;
 
 public partial class YargTabView : UserControl
 {
+    private static LedVisualizerWindow? _allDetachedWindow;
+    private static StrobeVisualizerWindow? _allStrobeWindow;
+    
+    private LedVisualizerWindow? _detachedWindow;
+    private StrobeVisualizerWindow? strobeVisualizerWindow;
+    private Grid? _mainGrid;
+    private LedVisualizerPanel? _originalVisualizer;
+    private bool _isVisualizerDetached = false;
+    
+    public static void CloseAllDetachedWindows()
+    {
+        // Close detached LED window
+        if (_allDetachedWindow != null && _allDetachedWindow.IsVisible)
+        {
+            try
+            {
+                _allDetachedWindow.Close();
+            }
+            catch (Exception) { }
+            _allDetachedWindow = null;
+        }
+        
+        // Close strobe window
+        if (_allStrobeWindow != null && _allStrobeWindow.IsVisible)
+        {
+            try
+            {
+                _allStrobeWindow.Close();
+            }
+            catch (Exception) { }
+            _allStrobeWindow = null;
+        }
+    }
+
     public YargTabView()
     {
         InitializeComponent();
+        _mainGrid = this.FindControl<Grid>("MainGrid");
+        _originalVisualizer = LedVisualizer;
+    }
+
+    private void OnDetachVisualizerClicked(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        var toggleButton = sender as Avalonia.Controls.Primitives.ToggleButton;
+        if (toggleButton?.IsChecked == true)
+        {
+            DetachLedVisualizer();
+        }
+        else
+        {
+            AttachLedVisualizer();
+        }
+    }
+    
+    private void OnStrobeVisualizerClicked(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        var toggleButton = sender as Avalonia.Controls.Primitives.ToggleButton;
+        if (toggleButton?.IsChecked == false)
+        {
+            // Close strobe visualizer
+            if (strobeVisualizerWindow != null)
+            {
+                strobeVisualizerWindow.Close();
+                strobeVisualizerWindow = null;
+            }
+        }
+        else
+        {
+            // Open strobe visualizer
+            if (strobeVisualizerWindow == null)
+            {
+                strobeVisualizerWindow = new StrobeVisualizerWindow();
+                _allStrobeWindow = strobeVisualizerWindow;
+                
+                strobeVisualizerWindow.Closed += (sender, e) =>
+                {
+                    // Reset button state when window is closed
+                    if (toggleButton != null)
+                    {
+                        toggleButton.IsChecked = false;
+                    }
+                    _allStrobeWindow = null;
+                    strobeVisualizerWindow = null;
+                };
+                strobeVisualizerWindow.Show();
+            }
+        }
+    }
+
+    private void DetachLedVisualizer()
+    {
+        if (_detachedWindow != null)
+        {
+            _detachedWindow.Activate();
+            return;
+        }
+
+        if (_isVisualizerDetached)
+        {
+            return;
+        }
+        
+        if (_originalVisualizer != null)
+        {
+            _originalVisualizer.IsVisible = false;
+            _originalVisualizer.Opacity = 0.0;
+            _originalVisualizer.Width = 0;
+            _originalVisualizer.Height = 0;
+            _originalVisualizer.Margin = new Avalonia.Thickness(-1000, -1000, 0, 0);
+            
+            var namedVisualizer = this.FindControl<LedVisualizerPanel>("LedVisualizer");
+            if (namedVisualizer != null)
+            {
+                namedVisualizer.IsVisible = false;
+                namedVisualizer.Opacity = 0.0;
+                namedVisualizer.Width = 0;
+                namedVisualizer.Height = 0;
+                namedVisualizer.Margin = new Avalonia.Thickness(-1000, -1000, 0, 0);
+            }
+            
+            if (_mainGrid != null)
+            {
+                var visualizersToRemove = _mainGrid.Children.OfType<LedVisualizerPanel>().ToList();
+                foreach (var viz in visualizersToRemove)
+                {
+                    _mainGrid.Children.Remove(viz);
+                }
+            }
+            
+            this.InvalidateVisual();
+            this.InvalidateMeasure();
+            this.InvalidateArrange();
+            
+            var dataGrid = this.FindControl<Avalonia.Controls.DataGrid>("MainDataGrid");
+            if (dataGrid != null)
+            {
+                Grid.SetColumnSpan(dataGrid, 2);
+                dataGrid.InvalidateVisual();
+            }
+            
+            _isVisualizerDetached = true;
+            DetachVisualizerButton.Content = "Attach LED Visualizer";
+        }
+
+        _detachedWindow = new LedVisualizerWindow();
+        _allDetachedWindow = _detachedWindow;
+        var mainWindow = this.VisualRoot as Window;
+        if (mainWindow != null)
+        {
+            var position = mainWindow.Position;
+            _detachedWindow.Position = new PixelPoint(
+                (int)(position.X + mainWindow.Width + 10),
+                (int)position.Y
+            );
+        }
+
+        _detachedWindow.Closed += (sender, e) =>
+        {
+            if (_detachedWindow != null)
+            {
+                _allDetachedWindow = null;
+            }
+            
+            _detachedWindow = null;
+            AttachLedVisualizer();
+        };
+
+        _detachedWindow.Show();
+    }
+
+    private void AttachLedVisualizer()
+    {
+        if (!_isVisualizerDetached)
+        {
+            return;
+        }
+
+        if (_detachedWindow != null)
+        {
+            _allDetachedWindow = null;
+            _detachedWindow.Close();
+            _detachedWindow = null;
+        }
+
+        if (_mainGrid != null)
+        {
+            var newVisualizer = new LedVisualizerPanel();
+            newVisualizer.DataContext = this.DataContext;
+            Grid.SetRow(newVisualizer, 3);
+            Grid.SetColumn(newVisualizer, 1);
+            newVisualizer.Height = 320;
+            newVisualizer.Width = 320;
+            newVisualizer.Margin = new Thickness(20, 0, 20, 0);
+            
+            _mainGrid.Children.Add(newVisualizer);
+            _originalVisualizer = newVisualizer;
+            
+            var dataGrid = this.FindControl<Avalonia.Controls.DataGrid>("MainDataGrid");
+            if (dataGrid != null)
+            {
+                Grid.SetColumnSpan(dataGrid, 1);
+            }
+            
+            _isVisualizerDetached = false;
+            DetachVisualizerButton.Content = "Detach LED Visualizer";
+            DetachVisualizerButton.IsChecked = false;
+        }
     }
 }

--- a/YALCY/Views/Windows/LedVisualizerWindow.axaml
+++ b/YALCY/Views/Windows/LedVisualizerWindow.axaml
@@ -1,0 +1,43 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:components="clr-namespace:YALCY.Views.Components"
+        x:Class="YALCY.Views.Windows.LedVisualizerWindow"
+        Title="Stage Kit LED Visualizer"
+        Width="400" Height="500"
+        MinWidth="200" MinHeight="200"
+        CanResize="True"
+        WindowStartupLocation="CenterOwner"
+        ExtendClientAreaToDecorationsHint="True"
+        Background="#0f111a">
+
+    <Grid RowDefinitions="Auto,*">
+        <!-- Simulated Title Bar Area -->
+        <Border Background="#4D000000" 
+                Height="30"
+                PointerPressed="OnTitleBarPointerPressed">
+            <StackPanel Orientation="Horizontal" Margin="0,0,140,0" Spacing="10">
+                <Button x:Name="PinButton"
+                        Width="35" Height="30"
+                        Background="Transparent"
+                        Foreground="White"
+                        BorderThickness="0"
+                        Click="OnPinButtonClick">
+                    <PathIcon Width="15" Height="15"
+                              Data="M160 96C160 78.3 174.3 64 192 64L448 64C465.7 64 480 78.3 480 96C480 113.7 465.7 128 448 128L418.5 128L428.8 262.1C465.9 283.3 494.6 318.5 507 361.8L510.8 375.2C513.6 384.9 511.6 395.2 505.6 403.3C499.6 411.4 490 416 480 416L160 416C150 416 140.5 411.3 134.5 403.3C128.5 395.3 126.5 384.9 129.3 375.2L133 361.8C145.4 318.5 174 283.3 211.2 262.1L221.5 128L192 128C174.3 128 160 113.7 160 96zM288 464L352 464L352 576C352 593.7 337.7 608 320 608C302.3 608 288 593.7 288 576L288 464z"/>
+                </Button>
+                <TextBlock Text="Stage Kit LED Visualizer" 
+                           VerticalAlignment="Center"
+                           Foreground="White"
+                           FontWeight="SemiBold"/>  
+            </StackPanel>
+        </Border>
+
+        <!-- Main Content Area -->
+        <Border Grid.Row="1" Padding="10">
+            <components:LedVisualizerPanel x:Name="WindowVisualizer" />
+        </Border>
+    </Grid>
+    
+</Window>

--- a/YALCY/Views/Windows/LedVisualizerWindow.axaml.cs
+++ b/YALCY/Views/Windows/LedVisualizerWindow.axaml.cs
@@ -1,0 +1,53 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using YALCY.Views.Components;
+
+namespace YALCY.Views.Windows;
+
+public partial class LedVisualizerWindow : Window
+{
+    public LedVisualizerWindow()
+    {
+        InitializeComponent();
+    }
+
+    public void SetVisualizerContent(LedVisualizerPanel content)
+    {
+    }
+
+    private void OnTitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // Enable window dragging when clicking on the title bar
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            this.BeginMoveDrag(e);
+        }
+    }
+
+    private void OnPinButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        // Toggle the "Always on Top" state
+        this.Topmost = !this.Topmost;
+        
+        // Update button appearance to show current state
+        if (PinButton != null)
+        {
+            var pathIcon = new PathIcon();
+            pathIcon.Width = 15;
+            pathIcon.Height = 15;
+            
+            if (this.Topmost)
+            {
+                // Active state - pin is active (crossed out pin icon)
+                pathIcon.Data = Geometry.Parse("M73 39.1C63.6 29.7 48.4 29.7 39.1 39.1C29.8 48.5 29.7 63.7 39 73.1L567 601.1C576.4 610.5 591.6 610.5 600.9 601.1C610.2 591.7 610.3 576.5 600.9 567.2L449.8 416L480 416C490 416 499.5 411.3 505.5 403.3C511.5 395.3 513.5 384.9 510.7 375.2L507 361.8C494.6 318.5 466 283.3 428.8 262.1L418.5 128L448 128C465.7 128 480 113.7 480 96C480 78.3 465.7 64 448 64L192 64C184.6 64 177.9 66.5 172.5 70.6L222.1 120.3L217.3 183.4L73 39.1zM314.2 416L181.7 283.6C159 304.1 141.9 331 133 361.9L129.2 375.3C126.4 385 128.4 395.3 134.4 403.4C140.4 411.5 150 416 160 416L314.2 416zM288 576C288 593.7 302.3 608 320 608C337.7 608 352 593.7 352 576L352 464L288 464L288 576z");
+            }
+            else
+            {
+                // Inactive state - pin is not active (filled pin icon)
+                pathIcon.Data = Geometry.Parse("M160 96C160 78.3 174.3 64 192 64L448 64C465.7 64 480 78.3 480 96C480 113.7 465.7 128 448 128L418.5 128L428.8 262.1C465.9 283.3 494.6 318.5 507 361.8L510.8 375.2C513.6 384.9 511.6 395.2 505.6 403.3C499.6 411.4 490 416 480 416L160 416C150 416 140.5 411.3 134.5 403.3C128.5 395.3 126.5 384.9 129.3 375.2L133 361.8C145.4 318.5 174 283.3 211.2 262.1L221.5 128L192 128C174.3 128 160 113.7 160 96zM288 464L352 464L352 576C352 593.7 337.7 608 320 608C302.3 608 288 593.7 288 576L288 464z");
+            }
+            PinButton.Content = pathIcon;
+        }
+    }
+}

--- a/YALCY/Views/Windows/StrobeVisualizerWindow.axaml
+++ b/YALCY/Views/Windows/StrobeVisualizerWindow.axaml
@@ -1,0 +1,92 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:components="clr-namespace:YALCY.Views.Components"
+        x:Class="YALCY.Views.Windows.StrobeVisualizerWindow"
+        Title="Strobe Visualizer"
+        Width="700" Height="500"
+        MinWidth="200" MinHeight="200"
+        CanResize="True"
+        WindowStartupLocation="CenterOwner"
+        ExtendClientAreaToDecorationsHint="True"
+        Background="#0f111a">
+
+    <Grid RowDefinitions="Auto,*">
+        <!-- Enhanced Title Bar with Status Info -->
+        <Border Background="#4D000000" 
+                Height="30"
+                PointerPressed="OnTitleBarPointerPressed">
+            <Grid ColumnDefinitions="Auto,*,Auto,Auto">
+                <!-- Pin Button -->
+                <StackPanel Orientation="Horizontal" Grid.Column="0">
+                    <Button x:Name="PinButton"
+                            Width="30" Height="30"
+                            Background="Transparent"
+                            Foreground="White"
+                            BorderThickness="0"
+                            Click="OnPinButtonClick">
+                        <PathIcon Width="15" Height="15"
+                                Data="M160 96C160 78.3 174.3 64 192 64L448 64C465.7 64 480 78.3 480 96C480 113.7 465.7 128 448 128L418.5 128L428.8 262.1C465.9 283.3 494.6 318.5 507 361.8L510.8 375.2C513.6 384.9 511.6 395.2 505.6 403.3C499.6 411.4 490 416 480 416L160 416C150 416 140.5 411.3 134.5 403.3C128.5 395.3 126.5 384.9 129.3 375.2L133 361.8C145.4 318.5 174 283.3 211.2 262.1L221.5 128L192 128C174.3 128 160 113.7 160 96zM288 464L352 464L352 576C352 593.7 337.7 608 320 608C302.3 608 288 593.7 288 576L288 464z"/>
+                    </Button>
+
+                    <!-- Dark Mode Button -->
+                    <Button x:Name="DarkButton"
+                            Width="30" Height="30"
+                            Background="Transparent"
+                            Foreground="White"
+                            BorderThickness="0"
+                            Click="OnDarkButtonClick">
+                        <PathIcon Width="15" Height="15"
+                                Data="M303.3 112.7C196.2 121.2 112 210.8 112 320C112 434.9 205.1 528 320 528C353.3 528 384.7 520.2 412.6 506.3C309.2 482.9 232 390.5 232 280C232 214.2 259.4 154.9 303.3 112.7zM64 320C64 178.6 178.6 64 320 64C339.4 64 358.4 66.2 376.7 70.3C386.6 72.5 394 80.8 395.2 90.8C396.4 100.8 391.2 110.6 382.1 115.2C321.5 145.4 280 207.9 280 280C280 381.6 362.4 464 464 464C469 464 473.9 463.8 478.8 463.4C488.9 462.6 498.4 468.2 502.6 477.5C506.8 486.8 504.6 497.6 497.3 504.6C451.3 548.8 388.8 576 320 576C178.6 576 64 461.4 64 320z"/>
+                    </Button>
+                </StackPanel>
+                
+                <!-- Title -->
+                <TextBlock Grid.Column="1"
+                           Text="Strobe Visualizer" 
+                           VerticalAlignment="Center"
+                           Foreground="White"
+                           FontWeight="SemiBold"
+                           Margin="10,0,0,0"/>
+                
+                <!-- Status Display -->
+                <StackPanel Grid.Column="2" 
+                            Orientation="Horizontal" 
+                            VerticalAlignment="Center" 
+                            Spacing="15"
+                            Margin="10,0,10,0">
+                    <TextBlock x:Name="StatusText" 
+                               Text="DISABLED" 
+                               Foreground="#cccccc" 
+                               FontSize="12" 
+                               FontWeight="Bold"/>
+                    <TextBlock Text="|" 
+                               Foreground="#666666" 
+                               FontSize="12"/>
+                    <TextBlock x:Name="SpeedText" 
+                               Text="Off @0" 
+                               Foreground="#cccccc" 
+                               FontSize="12" 
+                               FontWeight="Bold"/>
+                    <TextBlock Text="|" 
+                               Foreground="#666666" 
+                               FontSize="12"/>
+                </StackPanel>
+                
+                <!-- Window Controls Spacer -->
+                <Border Grid.Column="3" Width="140"/>
+            </Grid>
+        </Border>
+
+        <!-- Main Content Area -->
+        <Border x:Name="MainContent" Grid.Row="1" Padding="10">            
+            <!-- Strobe Effect Display -->
+            <Canvas x:Name="StrobeCanvas" 
+                    Background="#1a1d2a">
+                <!-- Strobe effects will be drawn here -->
+            </Canvas>
+        </Border>
+    </Grid>
+    
+</Window>

--- a/YALCY/Views/Windows/StrobeVisualizerWindow.axaml.cs
+++ b/YALCY/Views/Windows/StrobeVisualizerWindow.axaml.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using YALCY.Integrations.StageKit;
+using YALCY.Udp;
+using YALCY.Usb;
+
+namespace YALCY.Views.Windows;
+
+public partial class StrobeVisualizerWindow : Window
+{
+    private CancellationTokenSource cts = new();
+    private Task strobeTask = Task.CompletedTask;
+    private IBrush _strobeColor = Brushes.White;
+    private IBrush _strobeOffColor = new SolidColorBrush(Color.Parse("#1a1d2a"));
+    private bool _darkMode = false;
+
+    enum StrobeSpeed
+    {
+        Off,
+        Slow,
+        Medium,
+        Fast,
+        Fastest
+    }
+
+    public StrobeVisualizerWindow()
+    {
+        InitializeComponent();
+        UsbDeviceMonitor.OnStageKitCommand += OnStageKitEvent;
+        
+        // Initialize display
+        UpdateDisplay(false, StrobeSpeed.Off, 0);
+    }
+
+    private void OnTitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // Enable window dragging when clicking on the title bar
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            this.BeginMoveDrag(e);
+        }
+    }
+    private void OnStageKitEvent(StageKitTalker.CommandId commandId, byte parameter)
+    {
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            switch (commandId)
+            {
+                case StageKitTalker.CommandId.StrobeOff:
+                    StopStrobeEffect();
+                    break;
+
+                case StageKitTalker.CommandId.StrobeSlow:
+                    StartStrobeEffect(1);
+                    break;
+
+                case StageKitTalker.CommandId.StrobeMedium:
+                    StartStrobeEffect(2);
+                    break;
+
+                case StageKitTalker.CommandId.StrobeFast:
+                    StartStrobeEffect(3);
+                    break;
+
+                case StageKitTalker.CommandId.StrobeFastest:
+                    StartStrobeEffect(4);
+                    break;
+
+                case StageKitTalker.CommandId.DisableAll:
+                    StopStrobeEffect();
+                    break;
+            }
+        });
+    }
+
+    private void StartStrobeEffect(int speed)
+    {   
+        float bpm = UdpIntake.BeatsPerMinute.Value;
+        int interval = CalculateDelay(speed, bpm);
+        
+        cts = new CancellationTokenSource();
+        
+        strobeTask = Task.Run(async () =>
+        {
+            while (!cts.Token.IsCancellationRequested)
+            {
+                // Turn strobe ON
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    this.StrobeCanvas.Background = _strobeColor;
+                });
+                
+                await Task.Delay(interval, cts.Token);
+                
+                // Turn strobe OFF
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    this.StrobeCanvas.Background = _strobeOffColor;
+                });
+                
+                await Task.Delay(interval, cts.Token);
+            }
+        }, cts.Token);
+
+        UpdateDisplay(true, (StrobeSpeed)speed, (int)bpm);
+    }
+
+    private void StopStrobeEffect()
+    {
+        cts.Cancel();
+        
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            this.StrobeCanvas.Background = _strobeOffColor;
+            UpdateDisplay(false, StrobeSpeed.Off, 0);
+        });
+    }
+
+    private void UpdateDisplay(bool isActive, StrobeSpeed speed, int bpm)
+    {
+        if (StatusText != null)
+        {
+            StatusText.Text = isActive ? "On" : "Off";
+        }
+        
+        if (SpeedText != null)
+        {
+            if (isActive && speed != StrobeSpeed.Off)
+            {
+                SpeedText.Text = $"{speed} @{bpm}";
+            }
+        }
+    }
+
+    private int CalculateDelay(int speed, float bpm)
+    {
+        int noteValue = speed switch
+        {
+            1 => 16,  // Slow (16th note)
+            2 => 24,  // Medium (24th note)
+            3 => 32,  // Fast (32nd note)
+            4 => 64,  // Fastest (64th note)
+            _ => 16   // Default to slow
+        };
+
+        return (int)(60000.0 / bpm * 4 / noteValue);
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        UsbDeviceMonitor.OnStageKitCommand -= OnStageKitEvent;
+        cts.Cancel();
+        cts.Dispose();
+        base.OnClosed(e);
+    }
+
+    #region Windows management (pinning, dragging, etc.)
+
+    private void OnPinButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        this.Topmost = !this.Topmost;
+        
+        if (PinButton != null)
+        {
+            var pathIcon = new PathIcon();
+            pathIcon.Width = 15;
+            pathIcon.Height = 15;
+            
+            if (this.Topmost)
+            {
+                pathIcon.Data = Geometry.Parse("M73 39.1C63.6 29.7 48.4 29.7 39.1 39.1C29.8 48.5 29.7 63.7 39 73.1L567 601.1C576.4 610.5 591.6 610.5 600.9 601.1C610.2 591.7 610.3 576.5 600.9 567.2L449.8 416L480 416C490 416 499.5 411.3 505.5 403.3C511.5 395.3 513.5 384.9 510.7 375.2L507 361.8C494.6 318.5 466 283.3 428.8 262.1L418.5 128L448 128C465.7 128 480 113.7 480 96C480 78.3 465.7 64 448 64L192 64C184.6 64 177.9 66.5 172.5 70.6L222.1 120.3L217.3 183.4L73 39.1zM314.2 416L181.7 283.6C159 304.1 141.9 331 133 361.9L129.2 375.3C126.4 385 128.4 395.3 134.4 403.4C140.4 411.5 150 416 160 416L314.2 416zM288 576C288 593.7 302.3 608 320 608C337.7 608 352 593.7 352 576L352 464L288 464L288 576z");
+            }
+            else
+            {
+                pathIcon.Data = Geometry.Parse("M160 96C160 78.3 174.3 64 192 64L448 64C465.7 64 480 78.3 480 96C480 113.7 465.7 128 448 128L418.5 128L428.8 262.1C465.9 283.3 494.6 318.5 507 361.8L510.8 375.2C513.6 384.9 511.6 395.2 505.6 403.3C499.6 411.4 490 416 480 416L160 416C150 416 140.5 411.3 134.5 403.3C128.5 395.3 126.5 384.9 129.3 375.2L133 361.8C145.4 318.5 174 283.3 211.2 262.1L221.5 128L192 128C174.3 128 160 113.7 160 96zM288 464L352 464L352 576C352 593.7 337.7 608 320 608C302.3 608 288 593.7 288 576L288 464z");
+            }
+            PinButton.Content = pathIcon;
+        }
+    }
+
+    private void OnDarkButtonClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        this._darkMode = !this._darkMode;
+        var pathIcon = new PathIcon();
+        pathIcon.Width = 15;
+        pathIcon.Height = 15;
+
+        if (this._darkMode)
+        {
+            pathIcon.Data = Geometry.Parse("M320 64C178.6 64 64 178.6 64 320C64 461.4 178.6 576 320 576C388.8 576 451.3 548.8 497.3 504.6C504.6 497.6 506.7 486.7 502.6 477.5C498.5 468.3 488.9 462.6 478.8 463.4C473.9 463.8 469 464 464 464C362.4 464 280 381.6 280 280C280 207.9 321.5 145.4 382.1 115.2C391.2 110.7 396.4 100.9 395.2 90.8C394 80.7 386.6 72.5 376.7 70.3C358.4 66.2 339.4 64 320 64z");
+
+            _strobeOffColor = new SolidColorBrush(Color.Parse("#000000"));
+            this.Background = _strobeOffColor;
+            StrobeCanvas.Background = _strobeOffColor;
+            MainContent.Padding = new Thickness(0);
+        }
+        else
+        {
+            pathIcon.Data = Geometry.Parse("M303.3 112.7C196.2 121.2 112 210.8 112 320C112 434.9 205.1 528 320 528C353.3 528 384.7 520.2 412.6 506.3C309.2 482.9 232 390.5 232 280C232 214.2 259.4 154.9 303.3 112.7zM64 320C64 178.6 178.6 64 320 64C339.4 64 358.4 66.2 376.7 70.3C386.6 72.5 394 80.8 395.2 90.8C396.4 100.8 391.2 110.6 382.1 115.2C321.5 145.4 280 207.9 280 280C280 381.6 362.4 464 464 464C469 464 473.9 463.8 478.8 463.4C488.9 462.6 498.4 468.2 502.6 477.5C506.8 486.8 504.6 497.6 497.3 504.6C451.3 548.8 388.8 576 320 576C178.6 576 64 461.4 64 320z");
+
+            _strobeOffColor = new SolidColorBrush(Color.Parse("#1a1d2a"));
+            this.Background = new SolidColorBrush(Color.Parse("#0f111a"));
+            StrobeCanvas.Background = _strobeOffColor;
+            MainContent.Padding = new Thickness(10);
+        }
+
+        DarkButton.Content = pathIcon;
+    }
+
+    #endregion
+}

--- a/YALCY/YALCY.csproj
+++ b/YALCY/YALCY.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
+        <Version>1.2.0</Version>
         <OutputType>WinExe</OutputType>
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
Improves the application's usability and provides more flexibility with visualizer windows:

- Introduces detachable windows for the LED and Strobe visualizers, allowing users to position them independently.
- Enables a strobe visualizer with adjustable speed, controllable via Stage Kit commands.
- Closes all detached windows when the main window is closed, preventing orphaned windows.
- Updates LED position coordinates for better visual representation.

Refactors the application by introducing tabs for each integration
and implementing a status footer for improved visibility.

Adds PersonCard component with GitHub avatar loading for credits.

The status footer dynamically updates based on the connection status
of each integration (UDP, StageKit, DMX, RB3E, Serial, Hue, OpenRGB).

<img width="1217" height="764" alt="image" src="https://github.com/user-attachments/assets/c07e0469-5351-4df2-9d01-1d320e50b736" />
