### PR TITLE
Add sACN adapter selection dropdown and persistence

### DIFF
--- a/YALCY/SettingsManager.cs
+++ b/YALCY/SettingsManager.cs
@@ -20,6 +20,7 @@ public class SettingsContainer
     public ushort UdpListenPort { get; set; }
     public ushort OpenRgbServerPort { get; set; }
     public string? OpenRgbServerIp { get; set; }
+    public string? SacnAdapterIp { get; set; }
 }
 
 internal static class SettingsManager
@@ -43,6 +44,7 @@ internal static class SettingsManager
         UdpListenPort = 0,
         OpenRgbServerPort = 0,
         OpenRgbServerIp = "",
+        SacnAdapterIp = "",
     };
 
     public static bool UdpEnableSettingIsEnabled { get; set; }
@@ -88,6 +90,7 @@ internal static class SettingsManager
     public static ushort UdpListenPort { get; set; }
     public static ushort OpenRgbServerPort { get; set; }
     public static string? OpenRgbServerIp { get; set; }
+    public static string? SacnAdapterIp { get; set; }
 
     public static void SaveSettings(MainWindowViewModel mainViewModel)
     {
@@ -142,6 +145,7 @@ internal static class SettingsManager
 
         settings.OpenRgbServerIp = mainViewModel.OpenRgbServerIp;
         settings.OpenRgbServerPort = mainViewModel.OpenRgbServerPort;
+        settings.SacnAdapterIp = mainViewModel.SelectedSacnAdapter?.IpAddress;
 
         File.WriteAllText(SettingsFilePath, JsonConvert.SerializeObject(settings, Formatting.Indented));
     }
@@ -327,6 +331,7 @@ internal static class SettingsManager
 
             OpenRgbServerIp = container.OpenRgbServerIp;
             OpenRgbServerPort = container.OpenRgbServerPort;
+            SacnAdapterIp = container.SacnAdapterIp;
         }
         else // File is either garbage or doesn't exist. Load defaults.
         {
@@ -381,6 +386,7 @@ internal static class SettingsManager
 
             OpenRgbServerIp = "127.0.0.1";
             OpenRgbServerPort = 6742;
+            SacnAdapterIp = "";
         }
     }
 

--- a/YALCY/ViewModels/MainWindowViewModel.cs
+++ b/YALCY/ViewModels/MainWindowViewModel.cs
@@ -75,6 +75,7 @@ public partial class MainWindowViewModel : ViewModelBase, INotifyPropertyChanged
         //FeedInUsbSettings();
         //FeedInStageKitSettings();
         FeedInDmxSettings();
+        InitializeSacnAdapterOptions();
         //FeedInRb3eSettings();
         FeedInHueSettings();
         FeedInOpenRgbSettings();

--- a/YALCY/Views/Tabs/DmxSacnTabView.axaml
+++ b/YALCY/Views/Tabs/DmxSacnTabView.axaml
@@ -197,6 +197,13 @@
             <!-- Broadcast Settings Group -->
             <Border BorderBrush="White" BorderThickness="1" CornerRadius="5" Padding="10" Margin="0,0,0,10">
                 <StackPanel>
+                    <UniformGrid Columns="2" Margin="0,0,0,10">
+                        <TextBlock Text="sACN Adapter" VerticalAlignment="Center" Margin="5" />
+                        <ComboBox ItemsSource="{Binding SacnAdapterOptions}"
+                                  SelectedItem="{Binding SelectedSacnAdapter, Mode=TwoWay}"
+                                  DisplayMemberBinding="{Binding Name}"
+                                  Margin="5" />
+                    </UniformGrid>
                     <ItemsControl ItemsSource="{Binding BroadcastSettingsContainer}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>


### PR DESCRIPTION
### Motivation
- Provide a UI allowing the user to select which network adapter/address sACN output should bind to so multi-homed hosts can choose the correct NIC. 
- Persist the selected adapter across runs so the user doesn't need to reconfigure after restart. 
- Ensure the running sACN sender picks up changes immediately when the adapter selection is changed. 
- Default to the existing automatic behavior when no explicit adapter is chosen.

### Description
- Add a `SacnAdapterOption` type and populate `SacnAdapterOptions` by enumerating network interfaces in `ViewModels/DmxSettings.cs`, and add `InitializeSacnAdapterOptions()` to the main VM startup. 
- Add `SelectedSacnAdapter` to the `MainWindowViewModel` which saves the chosen IP to `SettingsManager.SacnAdapterIp` and restarts the sACN sender if `DmxTalker` is active. 
- Update `Integrations/DMX/DmxTalker.cs` to accept a resolved bind address when constructing `SACNClient`, expose `IsEnabled`, and add `ResolveBindAddress(...)` to prefer the selected adapter IP or fall back to the previous automatic address. 
- Add a ComboBox to the DMX/SACN tab (`Views/Tabs/DmxSacnTabView.axaml`) to surface the adapter list, and persist/load the setting via `SettingsManager.cs` (`SacnAdapterIp`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696346ad7d448324a83601f26c909abc)