### PR TITLE
Fix USB monitor threading and disconnect handling

### DIFF
--- a/YALCY/Usb/UsbDeviceMonitor.cs
+++ b/YALCY/Usb/UsbDeviceMonitor.cs
@@ -17,6 +17,10 @@ public class UsbDeviceMonitor
 {
     private DeviceList _list = DeviceList.Local; //complete device list
 
+    private static readonly object DeviceStateLock = new();
+    private readonly SemaphoreSlim _updateSemaphore = new(1, 1);
+    private CancellationTokenSource? _updateCts;
+
     private static List<HidDevice> _perviousHidDevices = new();
     private static List<SerialDevice> _perviousSerialDevices = new();
     private static List<BleDevice> _perviousBLEDevices = new();
@@ -65,82 +69,125 @@ public class UsbDeviceMonitor
     {
         Console.WriteLine("Device list changed, waiting for update...");
 
-        Dispatcher.UIThread.Post(async () =>
+        _updateCts?.Cancel();
+        _updateCts = new CancellationTokenSource();
+        var token = _updateCts.Token;
+        _ = Task.Run(() => RefreshDevicesAsync(token), token);
+    }
+
+    private async Task RefreshDevicesAsync(CancellationToken token)
+    {
+        var acquired = false;
+        try
         {
-            await Task.Delay(1000); // Give Windows time to update the device list
+            await _updateSemaphore.WaitAsync(token);
+            acquired = true;
+            await Task.Delay(1000, token); // Give Windows time to update the device list
 
             var newHidDevices = DeviceList.Local.GetHidDevices().ToList();
             var newSerialDevices = DeviceList.Local.GetSerialDevices().ToList();
             var newBleDevices = DeviceList.Local.GetBleDevices().ToList();
 
-            // Detect removed devices
-            foreach (var oldDev in _perviousSerialDevices)
+            List<HidDevice> previousHidDevices;
+            List<SerialDevice> previousSerialDevices;
+            List<BleDevice> previousBleDevices;
+
+            lock (DeviceStateLock)
             {
-                if (!newSerialDevices.Any(dev => dev.DevicePath == oldDev.DevicePath))
-                {
-                    Console.WriteLine("Serial device removed");
-                    DeviceRemoved?.Invoke(oldDev);
-                }
+                previousHidDevices = _perviousHidDevices.ToList();
+                previousSerialDevices = _perviousSerialDevices.ToList();
+                previousBleDevices = _perviousBLEDevices.ToList();
             }
 
-            foreach (var oldDev in _perviousHidDevices)
-            {
-                if (!newHidDevices.Any(dev => dev.DevicePath == oldDev.DevicePath))
-                {
-                    Console.WriteLine("HID device removed");
-                    DeviceRemoved?.Invoke(oldDev);
-                }
-            }
+            var removedSerialDevices = previousSerialDevices
+                .Where(oldDev => !newSerialDevices.Any(dev => dev.DevicePath == oldDev.DevicePath))
+                .ToList();
+            var removedHidDevices = previousHidDevices
+                .Where(oldDev => !newHidDevices.Any(dev => dev.DevicePath == oldDev.DevicePath))
+                .ToList();
+            var removedBleDevices = previousBleDevices
+                .Where(oldDev => !newBleDevices.Any(dev => dev.DevicePath == oldDev.DevicePath))
+                .ToList();
 
-            foreach (var oldDev in _perviousBLEDevices)
-            {
-                if (!newBleDevices.Any(dev => dev.DevicePath == oldDev.DevicePath))
-                {
-                    Console.WriteLine("BLE device removed");
-                    DeviceRemoved?.Invoke(oldDev);
-                }
-            }
+            var addedSerialDevices = newSerialDevices
+                .Where(newDev => !previousSerialDevices.Any(dev => dev.DevicePath == newDev.DevicePath))
+                .ToList();
+            var addedHidDevices = newHidDevices
+                .Where(newDev => !previousHidDevices.Any(dev => dev.DevicePath == newDev.DevicePath))
+                .Where(IsStageKitHidDevice)
+                .ToList();
+            var addedBleDevices = newBleDevices
+                .Where(newDev => !previousBleDevices.Any(dev => dev.DevicePath == newDev.DevicePath))
+                .ToList();
 
-            // Detect added devices
-            foreach (var newDev in newSerialDevices)
+            lock (DeviceStateLock)
             {
-                if (!_perviousSerialDevices.Any(dev => dev.DevicePath == newDev.DevicePath))
-                {
-                    Console.WriteLine("Serial device added");
-                    SerialDeviceAdded?.Invoke(newDev); //this is mostly for the serial talker watch dog
-                    DeviceInserted?.Invoke(newDev);
-                }
+                _perviousHidDevices = newHidDevices;
+                _perviousSerialDevices = newSerialDevices;
+                _perviousBLEDevices = newBleDevices;
+                _connectedHidDevices = newHidDevices.Where(IsStageKitHidDevice).ToList();
             }
-
-            foreach (var newDev in newHidDevices)
-            {
-                if (!_perviousHidDevices.Any(dev => dev.DevicePath == newDev.DevicePath))
-                {
-                    if ((newDev.VendorID != 0x1209 || newDev.ProductID != 0x2882 || newDev.ReleaseNumberBcd != 0x0900) && (newDev.VendorID != 0x0E6F || newDev.ProductID != 0x0103)) continue;
-                    Console.WriteLine("HID device added");
-                    DeviceInserted?.Invoke(newDev);
-                }
-            }
-
-            foreach (var newDev in newBleDevices)
-            {
-                if (!_perviousBLEDevices.Any(dev => dev.DevicePath == newDev.DevicePath))
-                {
-                    Console.WriteLine("BLE device added");
-                    DeviceInserted?.Invoke(newDev);
-                }
-            }
-
-            // Update the tracked device lists
-            _perviousHidDevices = newHidDevices;
-            _perviousSerialDevices = newSerialDevices;
-            _perviousBLEDevices = newBleDevices;
 
 #if WINDOWS
             UpdateConnectedXInputControllers();
 #endif
 
-        });
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                foreach (var oldDev in removedSerialDevices)
+                {
+                    Console.WriteLine("Serial device removed");
+                    DeviceRemoved?.Invoke(oldDev);
+                }
+
+                foreach (var oldDev in removedHidDevices)
+                {
+                    Console.WriteLine("HID device removed");
+                    DeviceRemoved?.Invoke(oldDev);
+                }
+
+                foreach (var oldDev in removedBleDevices)
+                {
+                    Console.WriteLine("BLE device removed");
+                    DeviceRemoved?.Invoke(oldDev);
+                }
+
+                foreach (var newDev in addedSerialDevices)
+                {
+                    Console.WriteLine("Serial device added");
+                    SerialDeviceAdded?.Invoke(newDev); //this is mostly for the serial talker watch dog
+                    DeviceInserted?.Invoke(newDev);
+                }
+
+                foreach (var newDev in addedHidDevices)
+                {
+                    Console.WriteLine("HID device added");
+                    DeviceInserted?.Invoke(newDev);
+                }
+
+                foreach (var newDev in addedBleDevices)
+                {
+                    Console.WriteLine("BLE device added");
+                    DeviceInserted?.Invoke(newDev);
+                }
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            // Swallow cancellations caused by device churn.
+        }
+        finally
+        {
+            if (acquired)
+            {
+                _updateSemaphore.Release();
+            }
+        }
     }
 
     public static void SendReport(StageKitTalker.CommandId commandId, byte parameter)
@@ -148,34 +195,66 @@ public class UsbDeviceMonitor
         OnStageKitCommand?.Invoke(commandId, parameter);
 
 #if WINDOWS
-        foreach (var controllerIndex in _connectedControllerIndices) // Only vibrate connected controllers
+        List<int> controllerIndices;
+        lock (DeviceStateLock)
+        {
+            controllerIndices = _connectedControllerIndices.ToList();
+        }
+
+        foreach (var controllerIndex in controllerIndices) // Only vibrate connected controllers
         {
             SetXInputVibration(controllerIndex, parameter, (byte)commandId);
         }
 #endif
 
-        foreach (var device in _connectedHidDevices)
+        List<HidDevice> hidDevices;
+        lock (DeviceStateLock)
         {
-            byte[] report;
-            if (device.VendorID == 0x1209 && device.ProductID == 0x2882 && device.ReleaseNumberBcd == 0x0900) //santroller sage kit
-            {
-                report = new byte[4];
-                report[0] = 0x01;
-                report[1] = 0x5A;
-                report[2] = parameter;
-                report[3] = (byte)commandId;
+            hidDevices = _connectedHidDevices.ToList();
+        }
 
-                var stream = device.Open();
+        foreach (var device in hidDevices)
+        {
+            if (!IsStageKitHidDevice(device))
+            {
+                continue;
+            }
+
+            var report = new byte[4];
+            report[0] = 0x01;
+            report[1] = 0x5A;
+            report[2] = parameter;
+            report[3] = (byte)commandId;
+
+            try
+            {
+                using var stream = device.Open();
                 stream.Write(report);
-                stream.Close();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to send HID report: {ex.Message}");
+                lock (DeviceStateLock)
+                {
+                    _connectedHidDevices.RemoveAll(connected => connected.DevicePath == device.DevicePath);
+                }
             }
         }
+    }
+
+    private static bool IsStageKitHidDevice(HidDevice device)
+    {
+        return (device.VendorID == 0x1209 && device.ProductID == 0x2882 && device.ReleaseNumberBcd == 0x0900)
+               || (device.VendorID == 0x0E6F && device.ProductID == 0x0103);
     }
 #if WINDOWS
     private void UpdateConnectedXInputControllers()
     {
         Console.WriteLine("Updating connected XInput controllers...");
-        _connectedControllerIndices.Clear();
+        lock (DeviceStateLock)
+        {
+            _connectedControllerIndices.Clear();
+        }
 
         for (int i = 0; i < 4; i++) // Check up to 4 controllers
         {
@@ -184,7 +263,10 @@ public class UsbDeviceMonitor
 
             if (result == 0) // Controller is connected
             {
-                _connectedControllerIndices.Add(i);
+                lock (DeviceStateLock)
+                {
+                    _connectedControllerIndices.Add(i);
+                }
             }
         }
     }


### PR DESCRIPTION
### Motivation
- USB disconnects could soft-lock the UI because device enumeration and HID I/O were run on the UI thread and lists could be mutated during iteration.
- Rapid device churn could cause concurrent refreshes and unhandled exceptions when devices disappear mid-iteration.
- HID write failures were not handled which could leave internal connected-device state inconsistent.

### Description
- Move device enumeration off the UI thread by replacing `OnDeviceListChanged` UI-posting with a background `RefreshDevicesAsync` worker and serialize refreshes using `_updateSemaphore` and a cancellation token source `_updateCts`.
- Snapshot and lock shared state using `DeviceStateLock` to avoid collection mutation during iteration and update `_pervious*` and `_connectedHidDevices` atomically; coalesce rapid changes by cancelling prior refreshes.
- Harden `SendReport` by snapshotting controller and HID lists before use, adding `IsStageKitHidDevice` helper, wrapping HID `device.Open()`/`Write()` in a `try/catch`, and removing failed devices from `_connectedHidDevices` on error.
- Make `UpdateConnectedXInputControllers` thread-safe by locking access to `_connectedControllerIndices`.

### Testing
- No automated tests were run for this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac043d92c832494c668f637fa0482)