### PR TITLE
Restore previous LIFX light state when disabling LifxTalker

### DIFF
--- a/YALCY/Integrations/Lifx/LifxModels.cs
+++ b/YALCY/Integrations/Lifx/LifxModels.cs
@@ -121,6 +121,7 @@ internal sealed class LifxLanDeviceModel
     public LifxHsbk BaseColor { get; set; }
     public int ExpectedZoneCount { get; set; } = 1;
     public List<LifxZoneModel> Zones { get; }
+    public LifxHsbk OriginalColor { get; set; }
 }
 
 internal sealed class LifxZoneModel
@@ -135,6 +136,7 @@ internal sealed class LifxZoneModel
     public int ZoneIndex { get; }
     public string AssignedStageLight { get; set; }
     public LifxHsbk CurrentColor { get; set; }
+    public LifxHsbk OriginalColor { get; set; }
 }
 
 internal readonly record struct LifxHsbk(ushort Hue, ushort Saturation, ushort Brightness, ushort Kelvin)

--- a/YALCY/Integrations/Lifx/LifxTalker.cs
+++ b/YALCY/Integrations/Lifx/LifxTalker.cs
@@ -45,6 +45,7 @@ public sealed class LifxTalker : IDisposable
     private List<LifxLanDeviceModel> _devices = new();
     private bool _isEnabled;
     private bool _isSubscribedToStageKit;
+    private bool _discoveryCompleted;
 
     public async Task EnableLifxLan(bool isEnabled, MainWindowViewModel? viewModel = null)
     {
@@ -61,10 +62,18 @@ public sealed class LifxTalker : IDisposable
             UpdateViewModelStatus("LIFX status: Discovering devices...", string.Empty);
             StatusFooter.UpdateStatus("LIFX", IntegrationStatus.Connecting);
             await DiscoverDevicesAsync(_mainViewModel);
+            _discoveryCompleted = true;
+            SaveColors(_devices);
             return;
         }
 
         _isEnabled = false;
+
+        if (_discoveryCompleted)
+        {
+            RestoreColors(_devices);
+        }
+
         UnsubscribeFromStageKit();
 
         lock (_socketLock)
@@ -698,6 +707,36 @@ public sealed class LifxTalker : IDisposable
             }
         }
     }
+    
+    private void SaveColors(IEnumerable<LifxLanDeviceModel> devices)
+    {
+        foreach (var device in devices)
+        {
+            foreach (var zone in device.Zones)
+            {
+                zone.OriginalColor = zone.CurrentColor;
+            }
+        }
+    }
+
+    private void RestoreColors(IEnumerable<LifxLanDeviceModel> devices)
+    {
+        var zoneList = new List<int>();
+        foreach (var device in devices)
+        {
+            zoneList.Clear();
+            foreach (var zone in device.Zones)
+            {
+                if (zone.AssignedStageLight != LifxStageAssignments.Unassigned)
+                {
+                    zone.CurrentColor = zone.OriginalColor;
+                    zoneList.Add(zone.ZoneIndex);
+                }
+            }
+
+            SendDeviceState(device, zoneList);
+        }
+    }
 
     private Dictionary<string, Dictionary<int, string>> GetSavedZoneAssignments()
     {
@@ -883,6 +922,7 @@ public sealed class LifxTalker : IDisposable
     public void Dispose()
     {
         UnsubscribeFromStageKit();
+        RestoreColors(_devices);
 
         lock (_socketLock)
         {

--- a/YALCY/Integrations/OpenRGB/OpenRgbTalker.cs
+++ b/YALCY/Integrations/OpenRGB/OpenRgbTalker.cs
@@ -116,6 +116,11 @@ public class OpenRgbTalker
         }
         else
         {
+            if (client == null)
+            {
+                return;
+            }
+            
             StatusFooter.UpdateStatus("OpenRGB", IntegrationStatus.Off);
             await _strobeCts.CancelAsync();
             await _fogCts.CancelAsync();

--- a/YALCY/ViewModels/MainWindowViewModel.cs
+++ b/YALCY/ViewModels/MainWindowViewModel.cs
@@ -203,7 +203,9 @@ public partial class MainWindowViewModel : ViewModelBase, INotifyPropertyChanged
 
     private async void ShutdownRequested(object? sender, ShutdownRequestedEventArgs e)
     {
+        e.Cancel = true;
         await ShutdownAsync();
+        _desktop?.Shutdown();
     }
 
     /// <summary>


### PR DESCRIPTION
Just a quick QoL improvement to automatically set LIFX lights back to their original state when YALCY is done with them.

* When discovering devices, we save the state of each zone
* Saved state is restored for any zones with stage kit mapping when Lifx integration is disabled or on application exit
* We do not restore if device discovery is not yet complete
* Also fixed a bug preventing the cleanup tasks in ShutdownAsync from running